### PR TITLE
feat(moltis): add BRAVE_API_KEY to externalsecret

### DIFF
--- a/kubernetes/apps/ai/moltis/app/externalsecret.yaml
+++ b/kubernetes/apps/ai/moltis/app/externalsecret.yaml
@@ -15,6 +15,7 @@ spec:
         MOLTIS_PASSWORD: "{{ .MOLTIS_PASSWORD }}"
         MOLTIS_API_KEY: "{{ .AGENTGATEWAY_API_KEY }}"
         FORGEJO_TOKEN: "{{ .FORGEJO_TOKEN }}"
+        BRAVE_API_KEY: "{{ .BRAVE_API_KEY }}"
         FORGEJO_API_TOKEN: "{{ .FORGEJO_TOKEN }}"
         ssh_private_key: "{{ .MOLTIS_SSH_PRIVATE_KEY }}"
         ssh_config: |
@@ -54,6 +55,8 @@ spec:
         key: chisel
     - extract:
         key: forgejo
+    - extract:
+        key: brave
     - extract:
         key: agentgateway
 ---


### PR DESCRIPTION
Enables web_search tool on the Moltis gateway. Pulls from brave 1Password item.