### PR TITLE
feat(moltis): add OPENAI_BASE_URL for local TTS/STT

### DIFF
--- a/kubernetes/apps/ai/moltis/app/externalsecret.yaml
+++ b/kubernetes/apps/ai/moltis/app/externalsecret.yaml
@@ -15,6 +15,7 @@ spec:
         MOLTIS_PASSWORD: "{{ .MOLTIS_PASSWORD }}"
         MOLTIS_API_KEY: "{{ .AGENTGATEWAY_API_KEY }}"
         FORGEJO_TOKEN: "{{ .FORGEJO_TOKEN }}"
+        OPENAI_BASE_URL: "https://gateway.goyangi.io/v1"
         BRAVE_API_KEY: "{{ .BRAVE_API_KEY }}"
         FORGEJO_API_TOKEN: "{{ .FORGEJO_TOKEN }}"
         ssh_private_key: "{{ .MOLTIS_SSH_PRIVATE_KEY }}"


### PR DESCRIPTION
Routes OpenAI audio API calls through kgateway → local Kokoro TTS + Parakeet STT on mac.internal:8000. Chat completions use custom-gateway provider so this only affects audio endpoints.