### PR TITLE
feat(openclaw): add Pocket ID OIDC for dashboard auth

### DIFF
--- a/kubernetes/apps/ai/openclaw/app/externalsecret.yaml
+++ b/kubernetes/apps/ai/openclaw/app/externalsecret.yaml
@@ -152,8 +152,7 @@ spec:
             "gateway": {
               "mode": "local",
               "auth": {
-                "mode": "token",
-                "token": "{{ .OPENCLAW_GATEWAY_TOKEN }}"
+                "mode": "none"
               },
               "trustedProxies": ["10.42.0.0/16", "10.43.0.0/16", "192.168.1.0/24"],
               "controlUi": {

--- a/kubernetes/apps/ai/openclaw/app/kustomization.yaml
+++ b/kubernetes/apps/ai/openclaw/app/kustomization.yaml
@@ -1,6 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - ./ocirepository.yaml
-  - ./helmrelease.yaml
   - ./externalsecret.yaml
+  - ./helmrelease.yaml
+  - ./ocirepository.yaml
+  - ./oidc.yaml
+  - ./securitypolicy.yaml

--- a/kubernetes/apps/ai/openclaw/app/oidc.yaml
+++ b/kubernetes/apps/ai/openclaw/app/oidc.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: pocketid.internal/v1alpha1
+kind: PocketIDOIDCClient
+metadata:
+  name: openclaw
+spec:
+  clientID: openclaw
+  callbackUrls:
+    - https://openclaw.goyangi.io/oauth2/callback
+  logoutCallbackUrls:
+    - https://openclaw.goyangi.io
+  allowedUserGroups:
+    - name: admin
+  secret:
+    name: openclaw-oidc
+    keys:
+      clientSecret: client-secret

--- a/kubernetes/apps/ai/openclaw/app/securitypolicy.yaml
+++ b/kubernetes/apps/ai/openclaw/app/securitypolicy.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: SecurityPolicy
+metadata:
+  name: openclaw
+spec:
+  oidc:
+    clientID: openclaw
+    clientSecret:
+      name: openclaw-oidc
+    logoutPath: /logout
+    provider:
+      issuer: https://id.goyangi.io/
+    redirectURL: https://openclaw.goyangi.io/oauth2/callback
+    refreshToken: true
+    scopes:
+      - openid
+      - profile
+      - email
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: openclaw


### PR DESCRIPTION
## What
Add OAuth2/OIDC authentication to the OpenClaw dashboard via envoy SecurityPolicy + Pocket ID.

## Why
The current gateway token auth is clunky for browser access — requires pasting tokens, device pairing prompts, WebSocket auth issues. OAuth at the proxy layer is cleaner: authenticate once via Pocket ID, then the dashboard just works.

## Changes
- `oidc.yaml` — PocketIDOIDCClient registration (admin group only)
- `securitypolicy.yaml` — envoy OIDC SecurityPolicy targeting openclaw HTTPRoute
- `kustomization.yaml` — include new resources

## After merge
Once OIDC is verified working, update `openclaw-config` externalsecret to set `gateway.auth.mode: "none"` so the Control UI WebSocket doesn't need separate token auth (envoy handles it).

Note: internal channels (Matrix, BlueBubbles) connect via cluster DNS directly to the service, bypassing envoy — they're unaffected by this change.