### PR TITLE
fix(kubeflow): update tensorboard CRD URL after manifests restructure

### DIFF
--- a/kubernetes/apps/kubeflow/tensorboard/app/kustomization.yaml
+++ b/kubernetes/apps/kubeflow/tensorboard/app/kustomization.yaml
@@ -6,4 +6,4 @@ resources:
   - ./helmrelease.yaml
   - ./rbac.yaml
   - ./httproute.yaml
-  - https://raw.githubusercontent.com/kubeflow/manifests/refs/heads/master/applications/tensorboard/tensorboard-controller/upstream/crd/bases/tensorboard.kubeflow.org_tensorboards.yaml
+  - https://raw.githubusercontent.com/kubeflow/manifests/refs/heads/master/applications/notebooks-v1/upstream/tensorboard-controller/crd/bases/tensorboard.kubeflow.org_tensorboards.yaml


### PR DESCRIPTION
Kubeflow moved `tensorboard-controller` from `applications/tensorboard/` to `applications/notebooks-v1/` as part of the notebooks-v1 consolidation.

This broke:
- flux-local CI (kustomize build fails on 404)
- Live tensorboard Kustomization (`Ready: False`, BuildFailed)

One-line fix: update the raw GitHub URL in the tensorboard kustomization.