### PR TITLE
feat(livekit): hybrid envoy + LBIPAM for signaling and UDP

### DIFF
--- a/kubernetes/apps/default/livekit/app/helmrelease.yaml
+++ b/kubernetes/apps/default/livekit/app/helmrelease.yaml
@@ -40,22 +40,24 @@ spec:
                     port: 7880
     service:
       app:
-        type: LoadBalancer
-        annotations:
-          lbipam.cilium.io/ips: 192.168.69.137,fd5d:a293:f321:69::137
-          external-dns.alpha.kubernetes.io/hostname: livekit.goyangi.io
-        externalTrafficPolicy: Local
         controller: livekit
         ports:
           http:
             port: 7880
             protocol: TCP
-          rtc-tcp:
-            port: 7881
-            protocol: TCP
+      udp:
+        type: LoadBalancer
+        controller: livekit
+        annotations:
+          lbipam.cilium.io/ips: 192.168.69.137,fd5d:a293:f321:69::137
+        externalTrafficPolicy: Local
+        ports:
           turn-udp:
             port: 3478
             protocol: UDP
+          rtc-tcp:
+            port: 7881
+            protocol: TCP
     persistence:
       config:
         type: configMap

--- a/kubernetes/apps/default/livekit/app/httproute.yaml
+++ b/kubernetes/apps/default/livekit/app/httproute.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: livekit
+  annotations:
+    external-dns.alpha.kubernetes.io/hostname: livekit.goyangi.io
+spec:
+  parentRefs:
+    - name: envoy-external
+      namespace: network
+      sectionName: https
+  hostnames:
+    - livekit.goyangi.io
+  rules:
+    - backendRefs:
+        - name: livekit-app
+          port: 7880

--- a/kubernetes/apps/default/livekit/app/kustomization.yaml
+++ b/kubernetes/apps/default/livekit/app/kustomization.yaml
@@ -4,4 +4,5 @@ kind: Kustomization
 resources:
   - externalsecret.yaml
   - helmrelease.yaml
+  - httproute.yaml
   - ocirepository.yaml


### PR DESCRIPTION
## What
Split LiveKit networking into hybrid approach:
- **Envoy HTTPRoute** for WSS signaling (port 7880) — TLS termination via envoy-external
- **Cilium LBIPAM LoadBalancer** for UDP media (TURN 3478, RTC TCP 7881)

## Why
Previous setup used single LoadBalancer for everything, but WebSocket signaling needs TLS termination (WSS). Envoy already handles this for all other services. UDP media traffic needs direct LoadBalancer path — can't proxy UDP through envoy.

## Changes
- Split `service.app` into ClusterIP (envoy backend) + `service.udp` LoadBalancer
- Add HTTPRoute through envoy-external for `livekit.goyangi.io`
- LBIPAM IP: `192.168.69.137` / `fd5d:a293:f321:69::137`
- `external-dns` annotation on HTTPRoute (not LB) for DNS
- `externalTrafficPolicy: Local` on LB for correct client IP

## Testing
- WSS signaling: `wss://livekit.goyangi.io` through envoy
- TURN UDP: `192.168.69.137:3478` direct
- RTC TCP fallback: `192.168.69.137:7881` direct