### PR TITLE
feat(temporal): migrate values to helm chart 1.0.0 schema

### DIFF
--- a/kubernetes/apps/ai/temporal/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/temporal/app/helmrelease.yaml
@@ -7,7 +7,7 @@ spec:
   chart:
     spec:
       chart: temporal
-      version: 0.74.0
+      version: 1.0.0
       sourceRef:
         kind: HelmRepository
         name: temporal
@@ -22,8 +22,6 @@ spec:
   values:
     server:
       replicaCount: 1
-      setConfigFilePath: true
-      configMapsToMount: sprig
       additionalInitContainers:
         - name: init-db
           image: ghcr.io/home-operations/postgres-init:18
@@ -31,36 +29,33 @@ spec:
             - secretRef:
                 name: temporal-secret
       config:
-        numHistoryShards: 512
         persistence:
           defaultStore: default
           visibilityStore: visibility
-          default:
-            driver: sql
-            sql:
-              driver: postgres12_pgx
-              host: postgres-rw.storage.svc.cluster.local
-              port: 5432
-              database: temporal
-              user: temporal
-              existingSecret: temporal-secret
-              secretName: temporal-secret
-              maxConns: 20
-              maxIdleConns: 20
-              maxConnLifetime: 1h
-          visibility:
-            driver: sql
-            sql:
-              driver: postgres12_pgx
-              host: postgres-rw.storage.svc.cluster.local
-              port: 5432
-              database: temporal_visibility
-              user: temporal
-              existingSecret: temporal-secret
-              secretName: temporal-secret
-              maxConns: 20
-              maxIdleConns: 20
-              maxConnLifetime: 1h
+          numHistoryShards: 512
+          datastores:
+            default:
+              sql:
+                pluginName: postgres12_pgx
+                databaseName: temporal
+                connectAddr: "postgres-rw.storage.svc.cluster.local:5432"
+                user: temporal
+                existingSecret: temporal-secret
+                secretKey: password
+                maxConns: 20
+                maxIdleConns: 20
+                maxConnLifetime: "1h"
+            visibility:
+              sql:
+                pluginName: postgres12_pgx
+                databaseName: temporal_visibility
+                connectAddr: "postgres-rw.storage.svc.cluster.local:5432"
+                user: temporal
+                existingSecret: temporal-secret
+                secretKey: password
+                maxConns: 20
+                maxIdleConns: 20
+                maxConnLifetime: "1h"
         namespaces:
           create: true
           namespace:
@@ -99,9 +94,10 @@ spec:
               name: temporal-oidc
               key: client_secret
     schema:
-      createDatabase:
-        enabled: false
       backoffLimit: 100
+    shims:
+      dockerize: false
+      elasticsearchTool: false
     cassandra:
       enabled: false
     elasticsearch:

--- a/kubernetes/apps/ai/temporal/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/temporal/app/helmrelease.yaml
@@ -98,11 +98,3 @@ spec:
     shims:
       dockerize: false
       elasticsearchTool: false
-    cassandra:
-      enabled: false
-    elasticsearch:
-      enabled: false
-    prometheus:
-      enabled: false
-    grafana:
-      enabled: false


### PR DESCRIPTION
Migrates temporal helm values from 0.74.0 to 1.0.0 schema.

**Breaking changes addressed:**
- `persistence.default/visibility` → `persistence.datastores.default/visibility`
- `driver` field removed (inferred from top-level key)
- `host:port` → `connectAddr` format
- `secretName` → `secretKey`
- `numHistoryShards` moved inside persistence block
- schema section simplified (removed `createDatabase.enabled`, `setup`, `update`)
- Removed deprecated `setConfigFilePath` and `configMapsToMount`
- Added `shims` (disabled — using server 1.30.3)

Supersedes #3426 (renovate version-only bump)