### PR TITLE
fix(liqo): disable API server IP remapping

### DIFF
--- a/kubernetes/apps/liqo-system/liqo/app/helmrelease.yaml
+++ b/kubernetes/apps/liqo-system/liqo/app/helmrelease.yaml
@@ -35,6 +35,9 @@ spec:
       metrics:
         serviceMonitor:
           enabled: true
+      pod:
+        extraArgs:
+          - --enable-api-server-ip-remapping=false
     gateway:
       metrics:
         serviceMonitor:


### PR DESCRIPTION
With external CIDR disabled (PR #3465), the API server IP remapping creates a black hole — VK kubeconfig gets rewritten to `10.40.0.1` (remapped external CIDR) which is unreachable.

Adding `--enable-api-server-ip-remapping=false` to controller-manager extraArgs so VK uses the public GKE API endpoint directly.

**Runtime fix already applied** — this makes it persistent across reconciliation.

Companion to #3465.