### PR TITLE
feat(runners): bump mono maxRunners to 8

### DIFF
--- a/kubernetes/apps/actions-runner-system/actions-runner-controller/runners/mono/helmrelease.yaml
+++ b/kubernetes/apps/actions-runner-system/actions-runner-controller/runners/mono/helmrelease.yaml
@@ -25,7 +25,7 @@ spec:
     githubConfigUrl: https://github.com/solanyn/mono
     githubConfigSecret: mono-runner-secret
     minRunners: 0
-    maxRunners: 2
+    maxRunners: 8
     controllerServiceAccount:
       name: actions-runner-controller
       namespace: actions-runner-system


### PR DESCRIPTION
GKE cpu-pool autoscales 0-4 spot nodes. 8 queued Bazel jobs bottlenecked on 2 runners.