### PR TITLE
feat: restore paperless-ngx + paperless-ai with Gemma 4

### DIFF
--- a/kubernetes/apps/default/kustomization.yaml
+++ b/kubernetes/apps/default/kustomization.yaml
@@ -66,3 +66,5 @@ resources:
   - ./zigbee/ks.yaml
   - ./zwave/ks.yaml
   - ./continuwuity/ks.yaml
+  - ./paperless/ks.yaml
+  - ./paperless-ai/ks.yaml

--- a/kubernetes/apps/default/paperless-ai/app/externalsecret.yaml
+++ b/kubernetes/apps/default/paperless-ai/app/externalsecret.yaml
@@ -1,0 +1,21 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: paperless-ai
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: paperless-ai-secret
+    template:
+      data:
+        OPENAI_API_KEY: "{{ .AGENTGATEWAY_API_KEY }}"
+        PAPERLESS_API_TOKEN: "{{ .PAPERLESS_API_TOKEN }}"
+  dataFrom:
+    - extract:
+        key: agentgateway
+    - extract:
+        key: paperless

--- a/kubernetes/apps/default/paperless-ai/app/helmrelease.yaml
+++ b/kubernetes/apps/default/paperless-ai/app/helmrelease.yaml
@@ -1,0 +1,80 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: paperless-ai
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: paperless-ai
+  interval: 1h
+  values:
+    controllers:
+      paperless-ai:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        containers:
+          app:
+            image:
+              repository: docker.io/clusterzx/paperless-ai
+              tag: 3.0.9
+            env:
+              PAPERLESS_AI_PORT: &port 3000
+              TZ: Australia/Sydney
+              AI_PROVIDER: openai
+              OPENAI_MODEL: gemma-4-e4b-it-4bit
+              OPENAI_BASE_URL: https://gateway.goyangi.io/v1/gemma-4
+              PAPERLESS_API_URL: http://paperless.default.svc.cluster.local:8000/api
+              RAG_SERVICE_ENABLED: "true"
+              RAG_SERVICE_URL: http://localhost:8000
+              SCAN_INTERVAL: "*/30 * * * *"
+              PUID: "1000"
+              PGID: "1000"
+            envFrom:
+              - secretRef:
+                  name: paperless-ai-secret
+            probes:
+              liveness: &probes
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /health
+                    port: *port
+                  initialDelaySeconds: 0
+                  periodSeconds: 10
+                  timeoutSeconds: 1
+                  failureThreshold: 3
+              readiness: *probes
+            securityContext:
+              allowPrivilegeEscalation: false
+              capabilities: {drop: ["ALL"]}
+              readOnlyRootFilesystem: true
+        pod:
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            runAsGroup: 1000
+            fsGroup: 1000
+            fsGroupChangePolicy: OnRootMismatch
+    persistence:
+      config:
+        existingClaim: "{{ .Release.Name }}"
+        globalMounts:
+          - path: /app/data
+      cache:
+        type: emptyDir
+        sizeLimit: 100Mi
+        globalMounts:
+          - path: /app/public/images
+      home:
+        type: emptyDir
+        globalMounts:
+          - path: /home/node
+    service:
+      app:
+        controller: paperless-ai
+        ports:
+          http:
+            port: *port

--- a/kubernetes/apps/default/paperless-ai/app/kustomization.yaml
+++ b/kubernetes/apps/default/paperless-ai/app/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./externalsecret.yaml
+  - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/default/paperless-ai/app/ocirepository.yaml
+++ b/kubernetes/apps/default/paperless-ai/app/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: paperless-ai
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 4.6.2
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/default/paperless-ai/ks.yaml
+++ b/kubernetes/apps/default/paperless-ai/ks.yaml
@@ -1,0 +1,25 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: paperless-ai
+spec:
+  targetNamespace: default
+  components:
+    - ../../../../components/volsync
+  dependsOn:
+    - name: paperless
+      namespace: default
+  interval: 1h
+  path: ./kubernetes/apps/default/paperless-ai/app
+  postBuild:
+    substitute:
+      APP: paperless-ai
+      VOLSYNC_CAPACITY: 5Gi
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  wait: false

--- a/kubernetes/apps/default/paperless/app/externalsecret.yaml
+++ b/kubernetes/apps/default/paperless/app/externalsecret.yaml
@@ -1,0 +1,34 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: paperless
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: paperless-secret
+    template:
+      data:
+        PAPERLESS_ADMIN_USER: "{{ .PAPERLESS_ADMIN_USER }}"
+        PAPERLESS_ADMIN_PASSWORD: "{{ .PAPERLESS_ADMIN_PASSWORD }}"
+        PAPERLESS_SECRET_KEY: "{{ .PAPERLESS_SECRET_KEY }}"
+        PAPERLESS_DBHOST: &dbHost postgres-rw.storage.svc.cluster.local
+        PAPERLESS_DBNAME: &dbName paperless
+        PAPERLESS_DBUSER: &dbUser "{{ .PAPERLESS_POSTGRES_USER }}"
+        PAPERLESS_DBPASS: &dbPass "{{ .PAPERLESS_POSTGRES_PASSWORD }}"
+        PAPERLESS_DBPORT: "5432"
+        # Init container
+        INIT_POSTGRES_HOST: *dbHost
+        INIT_POSTGRES_DBNAME: *dbName
+        INIT_POSTGRES_USER: *dbUser
+        INIT_POSTGRES_PASS: *dbPass
+        INIT_POSTGRES_SUPER_USER: postgres
+        INIT_POSTGRES_SUPER_PASS: "{{ .POSTGRES_SUPER_PASS }}"
+  dataFrom:
+    - extract:
+        key: paperless
+    - extract:
+        key: cloudnative-pg

--- a/kubernetes/apps/default/paperless/app/helmrelease.yaml
+++ b/kubernetes/apps/default/paperless/app/helmrelease.yaml
@@ -1,0 +1,105 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: paperless
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: paperless
+  interval: 1h
+  values:
+    controllers:
+      paperless:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        initContainers:
+          init-db:
+            image:
+              repository: ghcr.io/home-operations/postgres-init
+              tag: 18
+            envFrom:
+              - secretRef:
+                  name: paperless-secret
+        containers:
+          app:
+            image:
+              repository: ghcr.io/paperless-ngx/paperless-ngx
+              tag: 2.20.13
+            env:
+              PAPERLESS_PORT: &port 8000
+              PAPERLESS_TIME_ZONE: Australia/Sydney
+              PAPERLESS_URL: https://paperless.goyangi.io
+              PAPERLESS_DBENGINE: postgresql
+              PAPERLESS_REDIS: redis://redis.storage.svc.cluster.local:6379/0
+              PAPERLESS_CONSUMPTION_DIR: /inbox
+              PAPERLESS_DATA_DIR: /data
+              PAPERLESS_MEDIA_ROOT: /data
+              PAPERLESS_CONVERT_TMPDIR: /scratch
+              PAPERLESS_OCR_LANGUAGE: eng
+              PAPERLESS_TASK_WORKERS: 2
+              PAPERLESS_THREADS_PER_WORKER: 2
+              PAPERLESS_WEBSERVER_WORKERS: 2
+              PAPERLESS_CONSUMER_POLLING: 360
+              PAPERLESS_CONSUMER_RECURSIVE: true
+              PAPERLESS_CONSUMER_SUBDIRS_AS_TAGS: true
+              PAPERLESS_ENABLE_COMPRESSION: false
+              PAPERLESS_ENABLE_FLOWER: true
+              PAPERLESS_OCR_SKIP_ARCHIVE_FILE: with_text
+              USERMAP_UID: 1000
+              USERMAP_GID: 1000
+            envFrom:
+              - secretRef:
+                  name: paperless-secret
+            probes:
+              liveness:
+                enabled: true
+              readiness:
+                enabled: true
+              startup:
+                enabled: true
+                spec:
+                  failureThreshold: 30
+                  periodSeconds: 5
+            securityContext:
+              allowPrivilegeEscalation: false
+              capabilities: {drop: ["ALL"]}
+              readOnlyRootFilesystem: true
+        pod:
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 1000
+            runAsGroup: 1000
+            fsGroup: 1000
+            fsGroupChangePolicy: OnRootMismatch
+    persistence:
+      data:
+        existingClaim: "{{ .Release.Name }}"
+      inbox:
+        type: emptyDir
+        sizeLimit: 1Mi
+      run:
+        type: emptyDir
+        medium: Memory
+        sizeLimit: 100Mi
+      scratch:
+        type: emptyDir
+        sizeLimit: 1Gi
+      tmp:
+        type: emptyDir
+        medium: Memory
+        sizeLimit: 100Mi
+    route:
+      app:
+        hostnames:
+          - "{{ .Release.Name }}.goyangi.io"
+        parentRefs:
+          - name: envoy-internal
+            namespace: network
+    service:
+      app:
+        controller: paperless
+        ports:
+          http:
+            port: *port

--- a/kubernetes/apps/default/paperless/app/kustomization.yaml
+++ b/kubernetes/apps/default/paperless/app/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./externalsecret.yaml
+  - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/default/paperless/app/ocirepository.yaml
+++ b/kubernetes/apps/default/paperless/app/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: paperless
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 4.6.2
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/default/paperless/ks.yaml
+++ b/kubernetes/apps/default/paperless/ks.yaml
@@ -1,0 +1,25 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: paperless
+spec:
+  targetNamespace: default
+  components:
+    - ../../../../components/volsync
+  dependsOn:
+    - name: cloudnative-pg-cluster
+      namespace: storage
+  interval: 1h
+  path: ./kubernetes/apps/default/paperless/app
+  postBuild:
+    substitute:
+      APP: paperless
+      VOLSYNC_CAPACITY: 10Gi
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  wait: false


### PR DESCRIPTION
Restore paperless-ngx (2.20.13) and paperless-ai (3.0.9) using Gemma 4 via agentgateway.