### PR TITLE
fix(headscale-gateway): add TS_TAILSCALED_EXTRA_ARGS for login server

### DIFF
--- a/kubernetes/apps/network/headscale-gateway/app/helmrelease.yaml
+++ b/kubernetes/apps/network/headscale-gateway/app/helmrelease.yaml
@@ -22,6 +22,7 @@ spec:
             env:
               # Connect to Headscale, not Tailscale SaaS
               TS_LOGIN_SERVER: https://headscale.goyangi.io
+              TS_TAILSCALED_EXTRA_ARGS: "--login-server=https://headscale.goyangi.io"
               # Advertise routes to cluster API server and pod/service CIDRs
               TS_EXTRA_ARGS: "--advertise-routes=192.168.42.0/24,10.43.0.0/16,10.42.0.0/16 --accept-routes --snat-subnet-routes=false"
               TS_USERSPACE: "false"
@@ -43,6 +44,8 @@ spec:
       securityContext:
         runAsUser: 0
         runAsGroup: 0
+    serviceAccount:
+      headscale-gateway: {}
     persistence:
       tun:
         type: hostPath

--- a/kubernetes/apps/network/headscale-gateway/app/kustomization.yaml
+++ b/kubernetes/apps/network/headscale-gateway/app/kustomization.yaml
@@ -5,3 +5,4 @@ resources:
   - externalsecret.yaml
   - helmrelease.yaml
   - ocirepository.yaml
+  - rbac.yaml

--- a/kubernetes/apps/network/headscale-gateway/app/rbac.yaml
+++ b/kubernetes/apps/network/headscale-gateway/app/rbac.yaml
@@ -1,0 +1,31 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: headscale-gateway
+  namespace: network
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    resourceNames: ["headscale-gateway-state"]
+    verbs: ["get", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["create"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["get", "create", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: headscale-gateway
+  namespace: network
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: headscale-gateway
+subjects:
+  - kind: ServiceAccount
+    name: headscale-gateway
+    namespace: network


### PR DESCRIPTION
TS_LOGIN_SERVER alone not sufficient in containerboot v1.96.5. Add --login-server via TS_TAILSCALED_EXTRA_ARGS.