### PR TITLE
fix(nodepool): fallback to status.templateName for selfLink

### DIFF
--- a/kubernetes/apps/crossplane-system/crossplane/definitions/composition.yaml
+++ b/kubernetes/apps/crossplane-system/crossplane/definitions/composition.yaml
@@ -26,6 +26,9 @@ spec:
             {{- if and .observed.composed (index .observed.composed "instance-template") }}
             {{- $templateSelfLink = (index .observed.composed "instance-template").resource.status.atProvider.selfLinkUnique | default "" }}
             {{- end }}
+            {{- if not $templateSelfLink }}
+            {{- $templateSelfLink = .observed.composite.resource.status.templateName | default "" }}
+            {{- end }}
             ---
             apiVersion: compute.gcp.upbound.io/v1beta2
             kind: InstanceTemplate

--- a/kubernetes/apps/crossplane-system/crossplane/definitions/composition.yaml
+++ b/kubernetes/apps/crossplane-system/crossplane/definitions/composition.yaml
@@ -125,7 +125,6 @@ spec:
                   - compute-worker
                 labels:
                   managed-by: crossplane
-            {{- if $templateSelfLink }}
             ---
             apiVersion: compute.gcp.upbound.io/v1beta2
             kind: InstanceGroupManager
@@ -141,10 +140,11 @@ spec:
                 baseInstanceName: worker
                 zone: {{ $spec.region }}-b
                 targetSize: {{ $spec.targetSize }}
+                {{- if $templateSelfLink }}
                 version:
                   - instanceTemplate: {{ $templateSelfLink }}
                     name: primary
-            {{- end }}
+                {{- end }}
             ---
             apiVersion: home-ops.io/v1alpha1
             kind: XComputeNodePool


### PR DESCRIPTION
Fall back to XR status.templateName when observed.composed lacks instance-template mapping.