### PR TITLE
fix(nodepool): use TS_TAILSCALED_EXTRA_ARGS for login-server

### DIFF
--- a/kubernetes/apps/crossplane-system/crossplane/definitions/composition.yaml
+++ b/kubernetes/apps/crossplane-system/crossplane/definitions/composition.yaml
@@ -121,7 +121,8 @@ spec:
                     name: tailscale
                     environment:
                       - TS_AUTHKEY={{ $spec.headscaleAuthKey }}
-                      - TS_EXTRA_ARGS=--login-server=https://headscale.goyangi.io --accept-routes
+                      - TS_TAILSCALED_EXTRA_ARGS=--login-server=https://headscale.goyangi.io
+                      - TS_EXTRA_ARGS=--accept-routes
                 tags:
                   - compute-worker
                 labels:


### PR DESCRIPTION
Split tailscale env vars correctly for containerboot.