### PR TITLE
fix(headscale): allow tailscale-control-protocol upgrade

### DIFF
--- a/kubernetes/apps/network/headscale/app/backendtrafficpolicy.yaml
+++ b/kubernetes/apps/network/headscale/app/backendtrafficpolicy.yaml
@@ -11,6 +11,7 @@ spec:
   httpUpgrade:
     - type: DERP
     - type: websocket
+    - type: tailscale-control-protocol
   timeout:
     http:
       connectionIdleTimeout: 1h


### PR DESCRIPTION
Allow noise protocol upgrade through envoy for external clients.