### PR TITLE
fix(nodepool): add DNS nameservers for tailscale auth

### DIFF
--- a/kubernetes/apps/crossplane-system/crossplane/definitions/composition.yaml
+++ b/kubernetes/apps/crossplane-system/crossplane/definitions/composition.yaml
@@ -71,6 +71,10 @@ spec:
                             - 100.69.0.0/16
                       nodeLabels:
                         node-role.kubernetes.io/nodepool: "true"
+                      network:
+                        nameservers:
+                          - 8.8.8.8
+                          - 8.8.4.4
                       nodeTaints:
                         nodepool: "true:NoSchedule"
                       install:


### PR DESCRIPTION
Add Google DNS so workers can resolve headscale.goyangi.io during early boot.