### PR TITLE
fix(nodepool): use GCP metadata DNS for early boot resolution

### DIFF
--- a/kubernetes/apps/crossplane-system/crossplane/definitions/composition.yaml
+++ b/kubernetes/apps/crossplane-system/crossplane/definitions/composition.yaml
@@ -73,8 +73,8 @@ spec:
                         node-role.kubernetes.io/nodepool: "true"
                       network:
                         nameservers:
+                          - 169.254.169.254
                           - 8.8.8.8
-                          - 8.8.4.4
                       nodeTaints:
                         nodepool: "true:NoSchedule"
                       install:


### PR DESCRIPTION
Use link-local metadata DNS instead of public DNS for early boot.