### PR TITLE
fix(cloudflare-tunnel): route headscale directly, bypass envoy

### DIFF
--- a/kubernetes/apps/network/cloudflare-tunnel/app/helmrelease.yaml
+++ b/kubernetes/apps/network/cloudflare-tunnel/app/helmrelease.yaml
@@ -71,6 +71,12 @@ spec:
         data:
           config.yaml: |-
             ingress:
+              - hostname: headscale.goyangi.io
+                originRequest:
+                  http2Origin: false
+                  keepAliveTimeout: 3600s
+                  tcpKeepAlive: 7200s
+                service: http://headscale-app.{{ .Release.Namespace }}.svc.cluster.local:8080
               - hostname: "*.goyangi.io"
                 originRequest:
                   http2Origin: true


### PR DESCRIPTION
Noise protocol needs HTTP/1.1 Upgrade header. Route headscale directly.