### PR TITLE
fix(cloudflare-tunnel): add proxied DNS for headscale

### DIFF
--- a/kubernetes/apps/network/cloudflare-tunnel/app/dnsendpoint.yaml
+++ b/kubernetes/apps/network/cloudflare-tunnel/app/dnsendpoint.yaml
@@ -10,3 +10,7 @@ spec:
       recordType: CNAME
       targets:
         - ${CLOUDFLARE_TUNNEL_ID}.cfargotunnel.com
+    - dnsName: headscale.goyangi.io
+      recordType: CNAME
+      targets:
+        - ${CLOUDFLARE_TUNNEL_ID}.cfargotunnel.com


### PR DESCRIPTION
Route headscale.goyangi.io through Cloudflare tunnel for external access.