### PR TITLE
fix(nodepool): disable IPv6 on worker VMs

### DIFF
--- a/kubernetes/apps/crossplane-system/crossplane/definitions/composition.yaml
+++ b/kubernetes/apps/crossplane-system/crossplane/definitions/composition.yaml
@@ -89,6 +89,9 @@ spec:
                         kubePrism:
                           enabled: true
                           port: 7445
+                      sysctls:
+                        net.ipv6.conf.all.disable_ipv6: "1"
+                        net.ipv6.conf.default.disable_ipv6: "1"
                       kernel:
                         modules:
                           - name: nbd


### PR DESCRIPTION
Force IPv4 for Cloudflare-proxied headscale resolution.