### PR TITLE
fix(headscale): direct TCP path for noise protocol

### DIFF
--- a/kubernetes/apps/crossplane-system/crossplane/definitions/composition.yaml
+++ b/kubernetes/apps/crossplane-system/crossplane/definitions/composition.yaml
@@ -128,7 +128,7 @@ spec:
                     name: tailscale
                     environment:
                       - TS_AUTHKEY={{ $spec.headscaleAuthKey }}
-                      - TS_EXTRA_ARGS=--login-server=https://headscale.goyangi.io --accept-routes
+                      - TS_EXTRA_ARGS=--login-server=https://hs.goyangi.io:8443 --accept-routes
                 tags:
                   - compute-worker
                 labels:

--- a/kubernetes/apps/crossplane-system/crossplane/definitions/composition.yaml
+++ b/kubernetes/apps/crossplane-system/crossplane/definitions/composition.yaml
@@ -89,6 +89,9 @@ spec:
                         kubePrism:
                           enabled: true
                           port: 7445
+                      sysctls:
+                        net.ipv6.conf.all.disable_ipv6: "1"
+                        net.ipv6.conf.default.disable_ipv6: "1"
                       kernel:
                         modules:
                           - name: nbd

--- a/kubernetes/apps/network/cloudflare-tunnel/app/dnsendpoint.yaml
+++ b/kubernetes/apps/network/cloudflare-tunnel/app/dnsendpoint.yaml
@@ -10,7 +10,3 @@ spec:
       recordType: CNAME
       targets:
         - ${CLOUDFLARE_TUNNEL_ID}.cfargotunnel.com
-    - dnsName: headscale.goyangi.io
-      recordType: CNAME
-      targets:
-        - ${CLOUDFLARE_TUNNEL_ID}.cfargotunnel.com

--- a/kubernetes/apps/network/headscale/app/helmrelease.yaml
+++ b/kubernetes/apps/network/headscale/app/helmrelease.yaml
@@ -110,6 +110,16 @@ spec:
             port: 3000
           metrics:
             port: 9090
+      noise:
+        type: LoadBalancer
+        annotations:
+          lbipam.cilium.io/ips: 192.168.69.139
+        externalTrafficPolicy: Local
+        ports:
+          noise-tcp:
+            port: 443
+            targetPort: 8080
+            protocol: TCP
       stun:
         type: LoadBalancer
         ipFamilies: [IPv4, IPv6]


### PR DESCRIPTION
Bypass Cloudflare CDN for tailscale noise protocol. Requires UniFi port forward: WAN 8443 → 192.168.69.139:443.