### PR TITLE
fix(nodepool): use port 18443 for headscale

### DIFF
--- a/kubernetes/apps/crossplane-system/crossplane/definitions/composition.yaml
+++ b/kubernetes/apps/crossplane-system/crossplane/definitions/composition.yaml
@@ -128,7 +128,7 @@ spec:
                     name: tailscale
                     environment:
                       - TS_AUTHKEY={{ $spec.headscaleAuthKey }}
-                      - TS_EXTRA_ARGS=--login-server=https://hs.goyangi.io:8443 --accept-routes
+                      - TS_EXTRA_ARGS=--login-server=https://hs.goyangi.io:18443 --accept-routes
                 tags:
                   - compute-worker
                 labels:


### PR DESCRIPTION
Port 8443 conflicts with UDM management.