### PR TITLE
fix(nodepool): use http for headscale login server

### DIFF
--- a/kubernetes/apps/crossplane-system/crossplane/definitions/composition.yaml
+++ b/kubernetes/apps/crossplane-system/crossplane/definitions/composition.yaml
@@ -128,7 +128,7 @@ spec:
                     name: tailscale
                     environment:
                       - TS_AUTHKEY={{ $spec.headscaleAuthKey }}
-                      - TS_EXTRA_ARGS=--login-server=https://hs.goyangi.io:18443 --accept-routes
+                      - TS_EXTRA_ARGS=--login-server=http://hs.goyangi.io:18443 --accept-routes
                 tags:
                   - compute-worker
                 labels:


### PR DESCRIPTION
Noise LB forwards to plain HTTP. Noise protocol handles its own encryption.