### PR TITLE
fix(talos): static routes to nodepool subnet via k8s-2

### DIFF
--- a/talos/nodes/k8s-0.yaml.j2
+++ b/talos/nodes/k8s-0.yaml.j2
@@ -1,6 +1,12 @@
 ---
 machine:
   type: controlplane
+  network:
+    interfaces:
+      - interface: eno1
+        routes:
+          - network: 100.69.0.0/16
+            gateway: 192.168.42.12
   nodeLabels:
     topology.kubernetes.io/zone: m
 ---

--- a/talos/nodes/k8s-1.yaml.j2
+++ b/talos/nodes/k8s-1.yaml.j2
@@ -1,6 +1,12 @@
 ---
 machine:
   type: controlplane
+  network:
+    interfaces:
+      - interface: eno1
+        routes:
+          - network: 100.69.0.0/16
+            gateway: 192.168.42.12
   nodeLabels:
     topology.kubernetes.io/zone: m
 ---


### PR DESCRIPTION
Route 100.69.0.0/16 via k8s-2 for API server reachability.