### PR TITLE
fix(kubelet-csr-approver): use OCIRepository v1 API

### DIFF
--- a/kubernetes/apps/kube-system/kubelet-csr-approver/app/ocirepository.yaml
+++ b/kubernetes/apps/kube-system/kubelet-csr-approver/app/ocirepository.yaml
@@ -1,6 +1,6 @@
 ---
 # yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/source.toolkit.fluxcd.io/ocirepository_v1beta2.json
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: OCIRepository
 metadata:
   name: kubelet-csr-approver


### PR DESCRIPTION
v1beta2 not available in cluster