### PR TITLE
fix(nodepool): add node-labels kubelet extraArg for nodepool role

### DIFF
--- a/kubernetes/apps/crossplane-system/crossplane/definitions/composition.yaml
+++ b/kubernetes/apps/crossplane-system/crossplane/definitions/composition.yaml
@@ -67,6 +67,7 @@ spec:
                         extraArgs:
                           rotate-server-certificates: "true"
                           register-with-taints: "nodepool=true:NoSchedule"
+                          node-labels: "node-role.kubernetes.io/nodepool=true"
                         nodeIP:
                           validSubnets:
                             - 100.69.0.0/16


### PR DESCRIPTION
nodeLabels in Talos machine config not applied by NodeRestriction. Use kubelet extraArg instead.