### PR TITLE
fix(gateway): enable SNAT for subnet routes

### DIFF
--- a/kubernetes/apps/network/headscale-gateway/app/helmrelease.yaml
+++ b/kubernetes/apps/network/headscale-gateway/app/helmrelease.yaml
@@ -34,7 +34,7 @@ spec:
               # Connect to Headscale via noise LB (TLS-terminated by nginx sidecar)
               TS_LOGIN_SERVER: https://hs.goyangi.io
               # Advertise routes to cluster API server and pod/service CIDRs
-              TS_EXTRA_ARGS: "--login-server=https://hs.goyangi.io --advertise-routes=192.168.42.0/24,10.43.0.0/16,10.42.0.0/16 --accept-routes --snat-subnet-routes=false"
+              TS_EXTRA_ARGS: "--login-server=https://hs.goyangi.io --advertise-routes=192.168.42.0/24,10.43.0.0/16,10.42.0.0/16 --accept-routes"
               TS_USERSPACE: "false"
               TS_KUBE_SECRET: headscale-gateway-state
               TS_HOSTNAME: k8s-gateway


### PR DESCRIPTION
Remove --snat-subnet-routes=false. Workers can ping gateway but packets forwarded to pod/service CIDRs get dropped without MASQUERADE.