### PR TITLE
fix(network): add *.opencode.goyangi.io SAN to wildcard cert

### DIFF
--- a/kubernetes/apps/network/certificates/export/certificate.yaml
+++ b/kubernetes/apps/network/certificates/export/certificate.yaml
@@ -17,6 +17,7 @@ spec:
   dnsNames:
     - goyangi.io
     - "*.goyangi.io"
+    - "*.opencode.goyangi.io"
     - "*.work.goyangi.io"
     - "*.kobo.goyangi.io"
     - "*.s3.goyangi.io"


### PR DESCRIPTION
Wildcard certs only match one level deep.