### PR TITLE
fix: reparent audio routes to envoy-internal

### DIFF
--- a/kubernetes/apps/network/agentgateway/llm/audio.yaml
+++ b/kubernetes/apps/network/agentgateway/llm/audio.yaml
@@ -16,7 +16,7 @@ metadata:
   name: llm-tts
 spec:
   parentRefs:
-    - name: ai
+    - name: envoy-internal
       namespace: network
   rules:
     - matches:
@@ -33,7 +33,7 @@ metadata:
   name: llm-stt
 spec:
   parentRefs:
-    - name: ai
+    - name: envoy-internal
       namespace: network
   rules:
     - matches:
@@ -50,7 +50,7 @@ metadata:
   name: llm-vad
 spec:
   parentRefs:
-    - name: ai
+    - name: envoy-internal
       namespace: network
   rules:
     - matches:


### PR DESCRIPTION
agentgateway can't proxy raw HTTP — only LLM API calls. Move audio routes (TTS/STT/VAD) to envoy-internal.