### PR TITLE
feat(openclaw): add openebs-hostpath PVC for transient deps

### DIFF
--- a/kubernetes/apps/ai/openclaw/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/openclaw/app/helmrelease.yaml
@@ -422,6 +422,48 @@ spec:
         type: emptyDir
         globalMounts:
           - path: /certs
+      transient-cache:
+        type: persistentVolumeClaim
+        suffix: transient-cache
+        storageClass: openebs-hostpath
+        accessMode: ReadWriteOnce
+        size: 15Gi
+        advancedMounts:
+          openclaw:
+            install-tools:
+              - path: /home/node/.local
+                subPath: dot-local
+              - path: /home/node/.npm
+                subPath: dot-npm
+              - path: /home/node/.cache
+                subPath: dot-cache
+              - path: /home/node/.openclaw/workspace/.bun
+                subPath: workspace-bun
+              - path: /home/node/.openclaw/workspace/.venvs
+                subPath: workspace-venvs
+              - path: /home/node/.openclaw/workspace/.cache
+                subPath: workspace-cache
+              - path: /home/node/.openclaw/workspace/.local
+                subPath: workspace-local
+              - path: /home/node/.openclaw/workspace/node_modules
+                subPath: workspace-node-modules
+            app:
+              - path: /home/node/.local
+                subPath: dot-local
+              - path: /home/node/.npm
+                subPath: dot-npm
+              - path: /home/node/.cache
+                subPath: dot-cache
+              - path: /home/node/.openclaw/workspace/.bun
+                subPath: workspace-bun
+              - path: /home/node/.openclaw/workspace/.venvs
+                subPath: workspace-venvs
+              - path: /home/node/.openclaw/workspace/.cache
+                subPath: workspace-cache
+              - path: /home/node/.openclaw/workspace/.local
+                subPath: workspace-local
+              - path: /home/node/.openclaw/workspace/node_modules
+                subPath: workspace-node-modules
       docker-data:
         type: persistentVolumeClaim
         suffix: docker-data


### PR DESCRIPTION
## Summary

Adds a 15Gi openebs-hostpath PVC for recreatable dependencies that don't need VolSync backup.

**Before:** ~3.5G Ceph PVC backed up, 97% of which is transient deps
**After:** ~50M Ceph PVC (memory, scripts, skills, configs) + 15Gi local-only cache

### Transient dirs (openebs-hostpath, no backup):
- `~/.local` — uv, hippo, gog, fj binaries (1.1G)
- `~/.npm` — npm cache (473M)
- `~/.cache` — misc cache (42M)
- `~/.openclaw/workspace/.bun` — bun runtime (377M)
- `~/.openclaw/workspace/.venvs` — python venvs (31M)
- `~/.openclaw/workspace/.cache` — workspace cache (93M)
- `~/.openclaw/workspace/.local` — workspace local (303M)
- `~/.openclaw/workspace/node_modules` — npm deps (365M)

### Notes
- Uses subPath from single PVC to avoid multiple PVC claims
- install-tools initContainer populates these on first boot
- If node dies, deps get reinstalled on next pod start (acceptable tradeoff)
- docker-data already uses openebs-hostpath (same pattern)