### PR TITLE
feat(sparkyfitness): deploy SparkyFitness fitness tracker

### DIFF
--- a/kubernetes/apps/default/kustomization.yaml
+++ b/kubernetes/apps/default/kustomization.yaml
@@ -36,6 +36,7 @@ resources:
   - ./matter-server/ks.yaml
   - ./otbr/ks.yaml
   - ./mealie/ks.yaml
+  - ./sparkyfitness/ks.yaml
   - ./lake/ks.yaml
   - ./mlm/ks.yaml
   - ./buildkit/ks.yaml

--- a/kubernetes/apps/default/sparkyfitness/app/externalsecret.yaml
+++ b/kubernetes/apps/default/sparkyfitness/app/externalsecret.yaml
@@ -1,0 +1,35 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1beta1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: sparkyfitness
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: sparkyfitness-secret
+    template:
+      data:
+        # postgres-init
+        INIT_POSTGRES_HOST: postgres-rw.storage.svc.cluster.local
+        INIT_POSTGRES_SUPER_PASS: "{{ .POSTGRES_SUPER_PASS }}"
+        INIT_POSTGRES_USER: "{{ .SPARKYFITNESS_POSTGRES_USER }}"
+        INIT_POSTGRES_PASS: "{{ .SPARKYFITNESS_POSTGRES_PASSWORD }}"
+        INIT_POSTGRES_DBNAME: sparkyfitness
+        # server
+        SPARKY_FITNESS_DB_HOST: postgres-rw.storage.svc.cluster.local
+        SPARKY_FITNESS_DB_PORT: "5432"
+        SPARKY_FITNESS_DB_NAME: sparkyfitness
+        SPARKY_FITNESS_DB_USER: "{{ .SPARKYFITNESS_POSTGRES_USER }}"
+        SPARKY_FITNESS_DB_PASSWORD: "{{ .SPARKYFITNESS_POSTGRES_PASSWORD }}"
+        SPARKY_FITNESS_APP_DB_USER: "{{ .SPARKYFITNESS_POSTGRES_USER }}"
+        SPARKY_FITNESS_APP_DB_PASSWORD: "{{ .SPARKYFITNESS_POSTGRES_PASSWORD }}"
+        SPARKY_FITNESS_API_ENCRYPTION_KEY: "{{ .SPARKYFITNESS_API_ENCRYPTION_KEY }}"
+        BETTER_AUTH_SECRET: "{{ .SPARKYFITNESS_BETTER_AUTH_SECRET }}"
+  dataFrom:
+    - extract:
+        key: sparkyfitness
+    - extract:
+        key: cloudnative-pg

--- a/kubernetes/apps/default/sparkyfitness/app/helmrelease.yaml
+++ b/kubernetes/apps/default/sparkyfitness/app/helmrelease.yaml
@@ -9,13 +9,6 @@ spec:
     kind: OCIRepository
     name: sparkyfitness
   interval: 1h
-  install:
-    remediation:
-      retries: -1
-  upgrade:
-    cleanupOnFail: true
-    remediation:
-      retries: 3
   values:
     controllers:
       server:
@@ -40,7 +33,7 @@ spec:
               SPARKY_FITNESS_LOG_LEVEL: info
               SPARKY_FITNESS_FRONTEND_URL: https://sparkyfitness.goyangi.io
               SPARKY_FITNESS_DISABLE_SIGNUP: "true"
-              SPARKY_FITNESS_ADMIN_EMAIL: andrewchen1520@gmail.com
+              SPARKY_FITNESS_ADMIN_EMAIL: andrew@goyangi.io
               ALLOW_PRIVATE_NETWORK_CORS: "true"
               # OIDC
               OIDC_ENABLED: "true"

--- a/kubernetes/apps/default/sparkyfitness/app/helmrelease.yaml
+++ b/kubernetes/apps/default/sparkyfitness/app/helmrelease.yaml
@@ -1,0 +1,195 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: sparkyfitness
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: sparkyfitness
+  interval: 1h
+  install:
+    remediation:
+      retries: -1
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+  values:
+    controllers:
+      server:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        initContainers:
+          init-db:
+            image:
+              repository: ghcr.io/home-operations/postgres-init
+              tag: 18
+            envFrom: &envFrom
+              - secretRef:
+                  name: sparkyfitness-secret
+        containers:
+          app:
+            image:
+              repository: codewithcj/sparkyfitness_server
+              tag: v0.16.4.7
+            env:
+              TZ: Australia/Sydney
+              NODE_ENV: production
+              SPARKY_FITNESS_LOG_LEVEL: info
+              SPARKY_FITNESS_FRONTEND_URL: https://sparkyfitness.goyangi.io
+              SPARKY_FITNESS_DISABLE_SIGNUP: "true"
+              SPARKY_FITNESS_ADMIN_EMAIL: andrewchen1520@gmail.com
+              ALLOW_PRIVATE_NETWORK_CORS: "true"
+              # OIDC
+              OIDC_ENABLED: "true"
+              OIDC_PROVIDER_SLUG: pocketid
+              OIDC_PROVIDER_NAME: Pocket ID
+              OIDC_ISSUER_URL: https://id.goyangi.io
+              OIDC_SCOPE: "openid email profile"
+              OIDC_AUTO_REGISTER: "true"
+              OIDC_AUTO_REDIRECT: "true"
+              OIDC_CLIENT_ID: sparkyfitness
+              OIDC_CLIENT_SECRET:
+                valueFrom:
+                  secretKeyRef:
+                    name: sparkyfitness-oidc
+                    key: client_secret
+            envFrom: *envFrom
+            probes:
+              liveness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /api/health
+                    port: &serverPort 3010
+                  initialDelaySeconds: 30
+                  periodSeconds: 10
+                  timeoutSeconds: 10
+                  failureThreshold: 5
+              readiness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /api/health
+                    port: *serverPort
+                  initialDelaySeconds: 5
+                  periodSeconds: 5
+                  timeoutSeconds: 10
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities: { drop: ["ALL"] }
+            resources:
+              requests:
+                cpu: 10m
+                memory: 256Mi
+              limits:
+                memory: 1Gi
+      frontend:
+        pod:
+          securityContext:
+            runAsNonRoot: false
+            runAsUser: 0
+            runAsGroup: 0
+            fsGroup: 0
+        containers:
+          app:
+            image:
+              repository: codewithcj/sparkyfitness
+              tag: v0.16.4.7
+            env:
+              SPARKY_FITNESS_FRONTEND_URL: https://sparkyfitness.goyangi.io
+              SPARKY_FITNESS_SERVER_HOST: sparkyfitness-server
+              SPARKY_FITNESS_SERVER_PORT: "3010"
+            probes:
+              liveness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /
+                    port: &frontendPort 80
+                  initialDelaySeconds: 10
+                  periodSeconds: 10
+                  failureThreshold: 5
+              readiness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /
+                    port: *frontendPort
+                  initialDelaySeconds: 5
+                  periodSeconds: 5
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities:
+                drop: ["ALL"]
+                add: ["CHOWN", "NET_BIND_SERVICE", "SETGID", "SETUID"]
+            resources:
+              requests:
+                cpu: 10m
+                memory: 64Mi
+              limits:
+                memory: 256Mi
+    defaultPodOptions:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        fsGroupChangePolicy: OnRootMismatch
+        seccompProfile: { type: RuntimeDefault }
+    service:
+      server:
+        controller: server
+        ports:
+          http:
+            port: *serverPort
+      frontend:
+        controller: frontend
+        ports:
+          http:
+            port: *frontendPort
+    route:
+      app:
+        hostnames:
+          - sparkyfitness.goyangi.io
+        parentRefs:
+          - name: envoy-internal
+            namespace: network
+            sectionName: https
+        rules:
+          - backendRefs:
+              - name: sparkyfitness-frontend
+                port: 80
+    persistence:
+      uploads:
+        existingClaim: "{{ .Release.Name }}"
+        advancedMounts:
+          server:
+            app:
+              - path: /app/SparkyFitnessServer/uploads
+                subPath: uploads
+              - path: /app/SparkyFitnessServer/backup
+                subPath: backup
+      tmp:
+        type: emptyDir
+        advancedMounts:
+          server:
+            app:
+              - path: /tmp
+              - path: /app/SparkyFitnessServer/temp_uploads
+                subPath: temp_uploads
+          frontend:
+            app:
+              - path: /tmp
+              - path: /var/cache/nginx
+                subPath: nginx-cache
+              - path: /var/run
+                subPath: nginx-run

--- a/kubernetes/apps/default/sparkyfitness/app/kustomization.yaml
+++ b/kubernetes/apps/default/sparkyfitness/app/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./externalsecret.yaml
+  - ./helmrelease.yaml
+  - ./ocirepository.yaml
+  - ./oidc.yaml

--- a/kubernetes/apps/default/sparkyfitness/app/ocirepository.yaml
+++ b/kubernetes/apps/default/sparkyfitness/app/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: sparkyfitness
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 4.6.2
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/default/sparkyfitness/app/oidc.yaml
+++ b/kubernetes/apps/default/sparkyfitness/app/oidc.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: pocketid.internal/v1alpha1
+kind: PocketIDOIDCClient
+metadata:
+  name: sparkyfitness
+spec:
+  clientID: sparkyfitness
+  callbackUrls:
+    - https://sparkyfitness.goyangi.io/api/auth/callback/custom
+  logoutCallbackUrls:
+    - https://sparkyfitness.goyangi.io
+  secret:
+    name: sparkyfitness-oidc
+    keys:
+      clientSecret: client_secret

--- a/kubernetes/apps/default/sparkyfitness/ks.yaml
+++ b/kubernetes/apps/default/sparkyfitness/ks.yaml
@@ -1,0 +1,26 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: sparkyfitness
+spec:
+  targetNamespace: default
+  components:
+    - ../../../../components/volsync
+  dependsOn:
+    - name: pocket-id-resources
+      namespace: default
+    - name: cloudnative-pg-cluster
+      namespace: storage
+  interval: 1h
+  path: ./kubernetes/apps/default/sparkyfitness/app
+  postBuild:
+    substitute:
+      APP: sparkyfitness
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  wait: false


### PR DESCRIPTION
## What
Deploy SparkyFitness as a self-hosted fitness tracking platform.

## Architecture
- **Server**: Node.js API (codewithcj/sparkyfitness_server) on port 3010
- **Frontend**: Nginx (codewithcj/sparkyfitness) on port 80
- **Database**: CNPG postgres via postgres-init
- **Auth**: Pocket ID OIDC, signup disabled
- **Route**: envoy-internal at sparkyfitness.goyangi.io

## Features
- Nutrition, exercise, hydration, sleep, fasting, mood tracking
- Workout presets with rest timers (mobile app)
- Apple Health + Google Health Connect sync
- Multi-user / family profiles
- API + MCP server for programmatic access

## Prerequisites
Create `sparkyfitness` item in 1Password (kubernetes vault):
- `SPARKYFITNESS_POSTGRES_USER`
- `SPARKYFITNESS_POSTGRES_PASSWORD`
- `SPARKYFITNESS_API_ENCRYPTION_KEY` (64-char hex)
- `SPARKYFITNESS_BETTER_AUTH_SECRET`

## Security
- readOnlyRootFilesystem on both containers
- Non-root server (UID 1000), nginx root with minimal caps
- seccomp RuntimeDefault