### PR TITLE
fix(knative): move observability config out of _example block

### DIFF
--- a/kubernetes/apps/knative-serving/knative-serving/app/serving-core.yaml
+++ b/kubernetes/apps/knative-serving/knative-serving/app/serving-core.yaml
@@ -8494,6 +8494,13 @@ metadata:
   annotations:
     knative.dev/example-checksum: "f183bbc6"
 data:
+  metrics-protocol: "http/protobuf"
+  request-metrics-protocol: "http/protobuf"
+  request-metrics-endpoint: "http://vmauth-victoria-metrics-cluster.o11y.svc.cluster.local:8427/api/v1/otlp/v1/metrics"
+  request-metrics-export-interval: "60s"
+  tracing-protocol: "http/protobuf"
+  tracing-endpoint: "http://jaeger-collector.o11y:4318/v1/traces"
+  tracing-sampling-rate: "1"
   _example: |
     ################################
     #                              #
@@ -8587,7 +8594,7 @@ data:
     #
     # When the protocol is prometheus the endpoint can accept a 'host:port' string to customize the
     # listening host interface and port.
-    request-metrics-endpoint: http://vmauth-victoria-metrics-cluster.o11y.svc.cluster.local:8427/api/v1/otlp/v1/metrics
+    request-metrics-endpoint: http://example.com/v1/metrics
 
     # request-metrics-export-interval specifies the global metrics reporting period for the queue-proxy.
     #
@@ -8609,7 +8616,7 @@ data:
     #
     # The endpoint MUST be set when the protocol is http/protobuf or grpc.
     # The endpoint MUST NOT be set when the protocol is none.
-    tracing-endpoint: http://jaeger-collector.o11y:4318/v1/traces
+    tracing-endpoint: http://jaeger-collector.jaeger:4318/v1/traces
 
     # tracing-sampling-rate allows the user to specify what percentage of all traces should be exported
     # The value should be between 0 (never sample) to 1 (always sample)


### PR DESCRIPTION
The knative admission webhook rejects modifications to the _example key in ConfigMaps. The o11y namespace rename (PR #3730) changed URLs inside _example, causing Flux reconciliation failures.

Fix: move actual config values to top-level data block, revert _example URLs to upstream defaults.