### PR TITLE
fix(prometheus-adapter): correct vmauth URL and port, remove trino rule

### DIFF
--- a/kubernetes/apps/o11y/prometheus-adapter/app/helmrelease.yaml
+++ b/kubernetes/apps/o11y/prometheus-adapter/app/helmrelease.yaml
@@ -11,8 +11,8 @@ spec:
   interval: 1h
   values:
     prometheus:
-      url: http://vmauth-victoria-metrics-cluster.o11y.svc.cluster.local:8427
-      port: 9090
+      url: http://vmauth-victoria-metrics-cluster.o11y.svc.cluster.local
+      port: 8427
     rules:
       custom:
         # NFS availability — used by nfs-scaler component (10 apps)
@@ -41,13 +41,3 @@ spec:
           name:
             as: "zigbee_controller_available"
           metricsQuery: 'max_over_time(probe_success{instance=~"zigbee-controller.+"}[1m])'
-
-        # Trino running queries
-        - seriesQuery: 'trino_running_queries{service="trino"}'
-          resources:
-            overrides:
-              namespace: {resource: "namespace"}
-              service: {resource: "service"}
-          name:
-            as: "trino_running_queries"
-          metricsQuery: 'trino_running_queries{service="trino"}'


### PR DESCRIPTION
The prometheus-adapter chart concatenates `url` + `:` + `port`, so having `:8427` in the URL produced an invalid address (`host:8427:9090`). Custom metrics API was returning empty resources.

Fix: split URL and port correctly. Also removes the `trino_running_queries` rule since trino was removed in #3731.

Note: old KEDA HPAs (`keda-hpa-*`) still exist in the cluster and need manual cleanup:
```
kubectl delete hpa -n default keda-hpa-bazarr keda-hpa-brrpolice keda-hpa-ersatztv keda-hpa-immich keda-hpa-plex keda-hpa-qbittorrent keda-hpa-qui
kubectl delete hpa -n volsync-system keda-hpa-kopia
```