### PR TITLE
fix(prometheus-adapter): use vmsingle directly and pre-filter nfs metric

### DIFF
--- a/kubernetes/apps/o11y/prometheus-adapter/app/helmrelease.yaml
+++ b/kubernetes/apps/o11y/prometheus-adapter/app/helmrelease.yaml
@@ -11,14 +11,14 @@ spec:
   interval: 1h
   values:
     prometheus:
-      url: http://vmauth-victoria-metrics-cluster.o11y.svc.cluster.local
-      port: 8427
+      url: http://vmsingle-victoria-metrics-cluster.o11y.svc.cluster.local
+      port: 8428
     rules:
       default: false
       external:
-        - seriesQuery: '{__name__="probe_success"}'
+        - seriesQuery: 'probe_success{job="probe/o11y/nfs"}'
           resources:
             namespaced: false
           name:
-            as: probe_success
-          metricsQuery: max_over_time(<<.Series>>{<<.LabelMatchers>>}[1m])
+            as: nfs_available
+          metricsQuery: max_over_time(probe_success{job="probe/o11y/nfs"}[1m])

--- a/kubernetes/components/nfs-scaler/hpa.yaml
+++ b/kubernetes/components/nfs-scaler/hpa.yaml
@@ -14,10 +14,7 @@ spec:
     - type: External
       external:
         metric:
-          name: probe_success
-          selector:
-            matchLabels:
-              job: probe/o11y/nfs
+          name: nfs_available
         target:
           type: Value
           value: "1"


### PR DESCRIPTION
Two fixes for prometheus-adapter metric discovery:

1. **vmauth → vmsingle**: vmauth returns non-JSON responses for series discovery queries, causing `invalid character 'm' looking for beginning of value`. Point directly at vmsingle:8428 (same as onedr0p's setup).

2. **Pre-filter NFS metric**: The job label `probe/o11y/nfs` contains slashes which are invalid in k8s label selectors. Instead of relying on HPA label matching, pre-filter in the adapter rule and expose as `nfs_available` (no selector needed in HPA).

Tested in-cluster — `nfs_available` registers in external.metrics.k8s.io after these changes.