### PR TITLE
refactor(zeroscaler): align with onedr0p's proven prometheus-adapter setup

### DIFF
--- a/kubernetes/apps/default/bazarr/ks.yaml
+++ b/kubernetes/apps/default/bazarr/ks.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   targetNamespace: default
   components:
-    - ../../../../components/nfs-scaler
+    - ../../../../components/zeroscaler
     - ../../../../components/volsync
   dependsOn:
     - name: pocket-id-resources

--- a/kubernetes/apps/default/brrpolice/ks.yaml
+++ b/kubernetes/apps/default/brrpolice/ks.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   targetNamespace: default
   components:
-    - ../../../../components/nfs-scaler
+    - ../../../../components/zeroscaler
     - ../../../../components/volsync
   dependsOn:
     - name: rook-ceph-cluster

--- a/kubernetes/apps/default/calibre-web/ks.yaml
+++ b/kubernetes/apps/default/calibre-web/ks.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   targetNamespace: default
   components:
-    - ../../../../components/nfs-scaler
+    - ../../../../components/zeroscaler
     - ../../../../components/volsync
   dependsOn:
   - name: rook-ceph-cluster

--- a/kubernetes/apps/default/calibre/ks.yaml
+++ b/kubernetes/apps/default/calibre/ks.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   targetNamespace: default
   components:
-    - ../../../../components/nfs-scaler
+    - ../../../../components/zeroscaler
     - ../../../../components/volsync
   dependsOn:
   - name: calibre-web

--- a/kubernetes/apps/default/ersatztv/ks.yaml
+++ b/kubernetes/apps/default/ersatztv/ks.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   targetNamespace: default
   components:
-    - ../../../../components/nfs-scaler
+    - ../../../../components/zeroscaler
     - ../../../../components/volsync
   dependsOn:
     - name: pocket-id-resources

--- a/kubernetes/apps/default/immich/ks.yaml
+++ b/kubernetes/apps/default/immich/ks.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   targetNamespace: default
   components:
-    - ../../../../components/nfs-scaler
+    - ../../../../components/zeroscaler
   dependsOn:
     - name: cloudnative-pg-cluster
       namespace: storage

--- a/kubernetes/apps/default/plex/ks.yaml
+++ b/kubernetes/apps/default/plex/ks.yaml
@@ -6,7 +6,7 @@ metadata:
   name: plex
 spec:
   components:
-    - ../../../../components/nfs-scaler
+    - ../../../../components/zeroscaler
     - ../../../../components/volsync
   dependsOn:
     - name: intel-gpu-resource-driver

--- a/kubernetes/apps/default/qbittorrent/ks.yaml
+++ b/kubernetes/apps/default/qbittorrent/ks.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   targetNamespace: default
   components:
-    - ../../../../components/nfs-scaler
+    - ../../../../components/zeroscaler
     - ../../../../components/volsync
   dependsOn:
   - name: rook-ceph-cluster

--- a/kubernetes/apps/default/qui/ks.yaml
+++ b/kubernetes/apps/default/qui/ks.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   targetNamespace: default
   components:
-    - ../../../../components/nfs-scaler
+    - ../../../../components/zeroscaler
     - ../../../../components/volsync
   dependsOn:
     - name: pocket-id-resources

--- a/kubernetes/apps/o11y/blackbox-exporter/lan/probes.yaml
+++ b/kubernetes/apps/o11y/blackbox-exporter/lan/probes.yaml
@@ -23,6 +23,7 @@ kind: Probe
 metadata:
   name: nfs
 spec:
+  jobName: nfs_probe
   module: tcp_connect
   prober:
     url: blackbox-exporter.o11y.svc.cluster.local:9115

--- a/kubernetes/apps/volsync-system/kopia/ks.yaml
+++ b/kubernetes/apps/volsync-system/kopia/ks.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   targetNamespace: volsync-system
   components:
-  - ../../../../components/nfs-scaler
+  - ../../../../components/zeroscaler
   dependsOn:
   - name: volsync
     namespace: volsync-system

--- a/kubernetes/components/nfs-scaler/kustomization.yaml
+++ b/kubernetes/components/nfs-scaler/kustomization.yaml
@@ -1,6 +1,0 @@
----
-# yaml-language-server: $schema=https://json.schemastore.org/kustomization
-apiVersion: kustomize.config.k8s.io/v1alpha1
-kind: Component
-resources:
-  - ./hpa.yaml

--- a/kubernetes/components/zeroscaler/horizontalpodautoscaler.yaml
+++ b/kubernetes/components/zeroscaler/horizontalpodautoscaler.yaml
@@ -4,17 +4,20 @@ kind: HorizontalPodAutoscaler
 metadata:
   name: ${APP}
 spec:
+  minReplicas: 0
+  maxReplicas: 1
   scaleTargetRef:
     apiVersion: apps/v1
     kind: ${CONTROLLER:=Deployment}
     name: ${APP}
-  minReplicas: 0
-  maxReplicas: 1
   metrics:
     - type: External
       external:
         metric:
-          name: nfs_available
+          name: ${ZEROSCALER_METRIC_NAME:=probe_success}
+          selector:
+            matchLabels:
+              job: ${ZEROSCALER_JOB_NAME:=nfs_probe}
         target:
           type: Value
           value: "1"

--- a/kubernetes/components/zeroscaler/kustomization.yaml
+++ b/kubernetes/components/zeroscaler/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+resources:
+  - ./horizontalpodautoscaler.yaml


### PR DESCRIPTION
Copies onedr0p's working pattern exactly:

- **prometheus-adapter**: point at vmsingle:8428 directly (vmauth returns non-JSON for series discovery, breaking metric registration). Generic `probe_success` external rule with `namespaced: false`
- **blackbox-exporter**: add `jobName: nfs_probe` to NFS probe — gives a clean label without slashes for k8s selector compatibility
- **Rename nfs-scaler → zeroscaler**: matches onedr0p naming. HPA uses `type: External` with configurable `ZEROSCALER_METRIC_NAME` and `ZEROSCALER_JOB_NAME` vars (defaults: `probe_success` / `nfs_probe`)
- **Update all 10 ks.yaml refs** from nfs-scaler → zeroscaler

Tested in-cluster: vmsingle endpoint registers `probe_success` in external.metrics.k8s.io correctly.

Supersedes the adapter fixes in #3742 and #3743.