### PR TITLE
feat(lake): mount NFS /mnt/world/lake as /lake on lake-ingest

### DIFF
--- a/kubernetes/apps/default/lake/app/configmap.yaml
+++ b/kubernetes/apps/default/lake/app/configmap.yaml
@@ -45,6 +45,7 @@ data:
         "nsw_property_licences": {"description": "NSW property agent and corporation licences", "source_url": "https://api.onegov.nsw.gov.au/propertyregister/v1/browse", "source_name": "NSW Government", "update_frequency": "daily", "auth": "oauth2_client_credentials"},
         "nsw_trades_licences": {"description": "NSW trades and contractor licences", "source_url": "https://api.onegov.nsw.gov.au/tradesregister/v1/browse", "source_name": "NSW Government", "update_frequency": "daily", "auth": "oauth2_client_credentials"},
         "rss_feeds": {"description": "RSS/Atom feed articles with full extracted content from 50+ sources", "source_name": "Multiple (RSS/Atom feeds)", "update_frequency": "1h-24h per feed", "auth": "none"},
+        "bank": {"description": "Bank transactions from OFX files (Westpac offset/loan, CommBank shared)", "source_name": "Multiple banks", "update_frequency": "on-demand", "auth": "none"},
     }
 
     SILVER = {

--- a/kubernetes/apps/default/lake/app/helmrelease.yaml
+++ b/kubernetes/apps/default/lake/app/helmrelease.yaml
@@ -155,6 +155,14 @@ spec:
           ingest:
             register-tables:
               - path: /scripts
+      lake:
+        type: nfs
+        server: nas.internal
+        path: /mnt/world/lake
+        advancedMounts:
+          ingest:
+            app:
+              - path: /lake
     service:
       ingest:
         controller: ingest


### PR DESCRIPTION
Mounts `nas.internal:/mnt/world/lake` to `/lake` on the lake-ingest container.

Bank OFX files dropped at `/mnt/world/lake/bank/{provider}/{account}/` will be picked up by the bank ingest cron (mono PR #534).

The NFS mount is scoped to the ingest controller only — promote and aggregate don't need it.