### PR TITLE
fix: opencode workflows + mono runner on regular nodes

### DIFF
--- a/.github/workflows/opencode-review.yaml
+++ b/.github/workflows/opencode-review.yaml
@@ -36,7 +36,6 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-          token: ${{ steps.app-token.outputs.token }}
 
       - name: Run OpenCode Review
         uses: anomalyco/opencode/github@latest
@@ -45,7 +44,7 @@ jobs:
           OPENAI_BASE_URL: http://agentgateway.network.svc.cluster.local:8080/v1/opus
         with:
           model: openai/claude-opus-4-0520
-          token: ${{ steps.app-token.outputs.token }}
+          use_github_token: true
           prompt: |
             Review this pull request focusing on Kubernetes manifest correctness:
             - Validate HelmRelease values against the app-template chart schema

--- a/.github/workflows/opencode.yaml
+++ b/.github/workflows/opencode.yaml
@@ -32,7 +32,6 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-          token: ${{ steps.app-token.outputs.token }}
 
       - name: Run OpenCode
         uses: anomalyco/opencode/github@latest
@@ -41,4 +40,4 @@ jobs:
           OPENAI_BASE_URL: http://agentgateway.network.svc.cluster.local:8080/v1/opus
         with:
           model: openai/claude-opus-4-0520
-          token: ${{ steps.app-token.outputs.token }}
+          use_github_token: true

--- a/kubernetes/apps/actions-runner-system/actions-runner-controller/runners/mono/helmrelease.yaml
+++ b/kubernetes/apps/actions-runner-system/actions-runner-controller/runners/mono/helmrelease.yaml
@@ -31,13 +31,6 @@ spec:
       namespace: actions-runner-system
     template:
       spec:
-        nodeSelector:
-          node.kubernetes.io/nodepool: "true"
-        tolerations:
-          - key: nodepool
-            operator: Equal
-            value: "true"
-            effect: NoSchedule
         containers:
           - name: runner
             image: ghcr.io/home-operations/actions-runner:2.334.0@sha256:95d91d7f8d241e319ef2f4fec08f417aa1606b96fbb327643f75c303acd30002


### PR DESCRIPTION
- Switch secret from AGENTGATEWAY_API_KEY to OPENAI_API_KEY
- Drop deprecated `token` input from anomalyco/opencode action (use `use_github_token: true` instead)
- Remove nodepool nodeSelector + toleration from mono runner so it schedules on regular nodes