### PR TITLE
fix(argo): disable configmap watcher to fix CPU spike

### DIFF
--- a/kubernetes/apps/argo-system/argo-workflows/app/helmrelease.yaml
+++ b/kubernetes/apps/argo-system/argo-workflows/app/helmrelease.yaml
@@ -18,6 +18,11 @@ spec:
     controller:
       workflowNamespaces:
         - kubeflow
+      extraEnv:
+        - name: WATCH_CONTROLLER_SEMAPHORE_CONFIGMAPS
+          value: "false"
+      podAnnotations:
+        reloader.stakater.com/auto: "true"
     useDefaultArtifactRepo: true
     executor:
       securityContext:


### PR DESCRIPTION
Disables the buggy semaphore configmap RetryWatcher that causes a tight error loop and ~1 CPU core waste on k8s-0 (argoproj/argo-workflows#11657).

**Changes:**
- `WATCH_CONTROLLER_SEMAPHORE_CONFIGMAPS=false` env var on controller
- `reloader.stakater.com/auto: true` annotation so controller restarts on configmap changes

**Context:**
- Controller was burning 627m-977m CPU in a tight loop logging `invalid config map object received in semaphore config watcher`
- Zero workflows/cronworkflows running — no functional impact
- Workaround merged upstream in PR #12622 (v3.5.5+), proper fix (PR #11855) still open after 2 years
- Reloader annotation ensures hot-reload still works for configmap changes without the buggy watcher