### PR TITLE
feat(goldilocks): enable VPA recommendations for 5 more namespaces

### DIFF
--- a/kubernetes/apps/actions-runner-system/namespace.yaml
+++ b/kubernetes/apps/actions-runner-system/namespace.yaml
@@ -5,5 +5,7 @@ metadata:
   name: _
   annotations:
     kustomize.toolkit.fluxcd.io/prune: disabled
+    goldilocks.fairwinds.com/vpa-update-mode: Auto
+    goldilocks.fairwinds.com/vpa-resource-policy: '{"containerPolicies":[{"containerName":"*","maxAllowed":{"cpu":"100m","memory":"512Mi"}}]}'
   labels:
-    goldilocks.fairwinds.com/enabled: "true"
+    goldilocks.fairwinds.com/enabled: 'true'

--- a/kubernetes/apps/ai/namespace.yaml
+++ b/kubernetes/apps/ai/namespace.yaml
@@ -1,8 +1,11 @@
+---
 apiVersion: v1
 kind: Namespace
 metadata:
   name: _
   annotations:
     kustomize.toolkit.fluxcd.io/prune: disabled
+    goldilocks.fairwinds.com/vpa-update-mode: Auto
+    goldilocks.fairwinds.com/vpa-resource-policy: '{"containerPolicies":[{"containerName":"*","maxAllowed":{"cpu":"500m","memory":"2Gi"}}]}'
   labels:
-    goldilocks.fairwinds.com/enabled: "true"
+    goldilocks.fairwinds.com/enabled: 'true'

--- a/kubernetes/apps/argo-system/namespace.yaml
+++ b/kubernetes/apps/argo-system/namespace.yaml
@@ -1,8 +1,11 @@
+---
 apiVersion: v1
 kind: Namespace
 metadata:
   name: _
   annotations:
     kustomize.toolkit.fluxcd.io/prune: disabled
+    goldilocks.fairwinds.com/vpa-update-mode: Auto
+    goldilocks.fairwinds.com/vpa-resource-policy: '{"containerPolicies":[{"containerName":"*","maxAllowed":{"cpu":"100m","memory":"512Mi"}}]}'
   labels:
-    goldilocks.fairwinds.com/enabled: "true"
+    goldilocks.fairwinds.com/enabled: 'true'

--- a/kubernetes/apps/buildbarn/namespace.yaml
+++ b/kubernetes/apps/buildbarn/namespace.yaml
@@ -5,5 +5,7 @@ metadata:
   name: buildbarn
   annotations:
     kustomize.toolkit.fluxcd.io/prune: disabled
+    goldilocks.fairwinds.com/vpa-update-mode: Auto
+    goldilocks.fairwinds.com/vpa-resource-policy: '{"containerPolicies":[{"containerName":"*","maxAllowed":{"cpu":"100m","memory":"512Mi"}}]}'
   labels:
-    goldilocks.fairwinds.com/enabled: "true"
+    goldilocks.fairwinds.com/enabled: 'true'

--- a/kubernetes/apps/cert-manager/namespace.yaml
+++ b/kubernetes/apps/cert-manager/namespace.yaml
@@ -5,3 +5,5 @@ metadata:
   name: _
   annotations:
     kustomize.toolkit.fluxcd.io/prune: disabled
+  labels:
+    goldilocks.fairwinds.com/enabled: "true"

--- a/kubernetes/apps/cert-manager/namespace.yaml
+++ b/kubernetes/apps/cert-manager/namespace.yaml
@@ -5,5 +5,7 @@ metadata:
   name: _
   annotations:
     kustomize.toolkit.fluxcd.io/prune: disabled
+    goldilocks.fairwinds.com/vpa-update-mode: Auto
+    goldilocks.fairwinds.com/vpa-resource-policy: '{"containerPolicies":[{"containerName":"*","maxAllowed":{"cpu":"100m","memory":"512Mi"}}]}'
   labels:
-    goldilocks.fairwinds.com/enabled: "true"
+    goldilocks.fairwinds.com/enabled: 'true'

--- a/kubernetes/apps/crossplane-system/namespace.yaml
+++ b/kubernetes/apps/crossplane-system/namespace.yaml
@@ -7,4 +7,5 @@ metadata:
     kustomize.toolkit.fluxcd.io/prune: disabled
     volsync.backube/privileged-movers: "true"
   labels:
+    goldilocks.fairwinds.com/enabled: "true"
     resource.kubernetes.io/admin-access: "true"

--- a/kubernetes/apps/crossplane-system/namespace.yaml
+++ b/kubernetes/apps/crossplane-system/namespace.yaml
@@ -5,7 +5,9 @@ metadata:
   name: _
   annotations:
     kustomize.toolkit.fluxcd.io/prune: disabled
-    volsync.backube/privileged-movers: "true"
+    volsync.backube/privileged-movers: 'true'
+    goldilocks.fairwinds.com/vpa-update-mode: Auto
+    goldilocks.fairwinds.com/vpa-resource-policy: '{"containerPolicies":[{"containerName":"*","maxAllowed":{"cpu":"250m","memory":"1Gi"}}]}'
   labels:
-    goldilocks.fairwinds.com/enabled: "true"
-    resource.kubernetes.io/admin-access: "true"
+    goldilocks.fairwinds.com/enabled: 'true'
+    resource.kubernetes.io/admin-access: 'true'

--- a/kubernetes/apps/default/namespace.yaml
+++ b/kubernetes/apps/default/namespace.yaml
@@ -1,11 +1,13 @@
+---
 apiVersion: v1
 kind: Namespace
 metadata:
   name: _
   annotations:
     kustomize.toolkit.fluxcd.io/prune: disabled
-    volsync.backube/privileged-movers: "true"
+    volsync.backube/privileged-movers: 'true'
+    goldilocks.fairwinds.com/vpa-update-mode: Auto
+    goldilocks.fairwinds.com/vpa-resource-policy: '{"containerPolicies":[{"containerName":"*","maxAllowed":{"cpu":"250m","memory":"1Gi"}}]}'
   labels:
-    goldilocks.fairwinds.com/enabled: "true"
-    resource.kubernetes.io/admin-access: "true"
-
+    goldilocks.fairwinds.com/enabled: 'true'
+    resource.kubernetes.io/admin-access: 'true'

--- a/kubernetes/apps/external-secrets/namespace.yaml
+++ b/kubernetes/apps/external-secrets/namespace.yaml
@@ -5,3 +5,5 @@ metadata:
   name: _
   annotations:
     kustomize.toolkit.fluxcd.io/prune: disabled
+  labels:
+    goldilocks.fairwinds.com/enabled: "true"

--- a/kubernetes/apps/external-secrets/namespace.yaml
+++ b/kubernetes/apps/external-secrets/namespace.yaml
@@ -5,5 +5,7 @@ metadata:
   name: _
   annotations:
     kustomize.toolkit.fluxcd.io/prune: disabled
+    goldilocks.fairwinds.com/vpa-update-mode: Auto
+    goldilocks.fairwinds.com/vpa-resource-policy: '{"containerPolicies":[{"containerName":"*","maxAllowed":{"cpu":"100m","memory":"512Mi"}}]}'
   labels:
-    goldilocks.fairwinds.com/enabled: "true"
+    goldilocks.fairwinds.com/enabled: 'true'

--- a/kubernetes/apps/flux-system/namespace.yaml
+++ b/kubernetes/apps/flux-system/namespace.yaml
@@ -5,3 +5,5 @@ metadata:
   name: _
   annotations:
     kustomize.toolkit.fluxcd.io/prune: disabled
+  labels:
+    goldilocks.fairwinds.com/enabled: "true"

--- a/kubernetes/apps/flux-system/namespace.yaml
+++ b/kubernetes/apps/flux-system/namespace.yaml
@@ -5,5 +5,7 @@ metadata:
   name: _
   annotations:
     kustomize.toolkit.fluxcd.io/prune: disabled
+    goldilocks.fairwinds.com/vpa-update-mode: Auto
+    goldilocks.fairwinds.com/vpa-resource-policy: '{"containerPolicies":[{"containerName":"*","maxAllowed":{"cpu":"250m","memory":"1Gi"}}]}'
   labels:
-    goldilocks.fairwinds.com/enabled: "true"
+    goldilocks.fairwinds.com/enabled: 'true'

--- a/kubernetes/apps/knative-serving/namespace.yaml
+++ b/kubernetes/apps/knative-serving/namespace.yaml
@@ -4,6 +4,9 @@ kind: Namespace
 metadata:
   name: knative-serving
   labels:
-    goldilocks.fairwinds.com/enabled: "true"
+    goldilocks.fairwinds.com/enabled: 'true'
     app.kubernetes.io/name: knative-serving
-    app.kubernetes.io/version: "1.14.0"
+    app.kubernetes.io/version: 1.14.0
+  annotations:
+    goldilocks.fairwinds.com/vpa-update-mode: Auto
+    goldilocks.fairwinds.com/vpa-resource-policy: '{"containerPolicies":[{"containerName":"*","maxAllowed":{"cpu":"100m","memory":"512Mi"}}]}'

--- a/kubernetes/apps/kubeflow/namespace.yaml
+++ b/kubernetes/apps/kubeflow/namespace.yaml
@@ -1,8 +1,11 @@
+---
 apiVersion: v1
 kind: Namespace
 metadata:
   name: _
   annotations:
     kustomize.toolkit.fluxcd.io/prune: disabled
+    goldilocks.fairwinds.com/vpa-update-mode: Auto
+    goldilocks.fairwinds.com/vpa-resource-policy: '{"containerPolicies":[{"containerName":"*","maxAllowed":{"cpu":"100m","memory":"512Mi"}}]}'
   labels:
-    goldilocks.fairwinds.com/enabled: "true"
+    goldilocks.fairwinds.com/enabled: 'true'

--- a/kubernetes/apps/ml/namespace.yaml
+++ b/kubernetes/apps/ml/namespace.yaml
@@ -1,8 +1,11 @@
+---
 apiVersion: v1
 kind: Namespace
 metadata:
   name: _
   annotations:
     kustomize.toolkit.fluxcd.io/prune: disabled
+    goldilocks.fairwinds.com/vpa-update-mode: Auto
+    goldilocks.fairwinds.com/vpa-resource-policy: '{"containerPolicies":[{"containerName":"*","maxAllowed":{"cpu":"100m","memory":"512Mi"}}]}'
   labels:
-    goldilocks.fairwinds.com/enabled: "true"
+    goldilocks.fairwinds.com/enabled: 'true'

--- a/kubernetes/apps/network/namespace.yaml
+++ b/kubernetes/apps/network/namespace.yaml
@@ -5,5 +5,7 @@ metadata:
   name: _
   annotations:
     kustomize.toolkit.fluxcd.io/prune: disabled
+    goldilocks.fairwinds.com/vpa-update-mode: Auto
+    goldilocks.fairwinds.com/vpa-resource-policy: '{"containerPolicies":[{"containerName":"*","maxAllowed":{"cpu":"250m","memory":"1Gi"}}]}'
   labels:
-    goldilocks.fairwinds.com/enabled: "true"
+    goldilocks.fairwinds.com/enabled: 'true'

--- a/kubernetes/apps/o11y/namespace.yaml
+++ b/kubernetes/apps/o11y/namespace.yaml
@@ -5,5 +5,7 @@ metadata:
   name: _
   annotations:
     kustomize.toolkit.fluxcd.io/prune: disabled
+    goldilocks.fairwinds.com/vpa-update-mode: Auto
+    goldilocks.fairwinds.com/vpa-resource-policy: '{"containerPolicies":[{"containerName":"*","maxAllowed":{"cpu":"500m","memory":"2Gi"}}]}'
   labels:
-    goldilocks.fairwinds.com/enabled: "true"
+    goldilocks.fairwinds.com/enabled: 'true'

--- a/kubernetes/apps/renovate/namespace.yaml
+++ b/kubernetes/apps/renovate/namespace.yaml
@@ -5,5 +5,7 @@ metadata:
   name: renovate
   annotations:
     kustomize.toolkit.fluxcd.io/prune: disabled
+    goldilocks.fairwinds.com/vpa-update-mode: Auto
+    goldilocks.fairwinds.com/vpa-resource-policy: '{"containerPolicies":[{"containerName":"*","maxAllowed":{"cpu":"100m","memory":"512Mi"}}]}'
   labels:
-    goldilocks.fairwinds.com/enabled: "true"
+    goldilocks.fairwinds.com/enabled: 'true'

--- a/kubernetes/apps/storage/namespace.yaml
+++ b/kubernetes/apps/storage/namespace.yaml
@@ -5,5 +5,7 @@ metadata:
   name: _
   annotations:
     kustomize.toolkit.fluxcd.io/prune: disabled
+    goldilocks.fairwinds.com/vpa-update-mode: Auto
+    goldilocks.fairwinds.com/vpa-resource-policy: '{"containerPolicies":[{"containerName":"*","maxAllowed":{"cpu":"500m","memory":"2Gi"}}]}'
   labels:
-    goldilocks.fairwinds.com/enabled: "true"
+    goldilocks.fairwinds.com/enabled: 'true'

--- a/kubernetes/apps/streaming/namespace.yaml
+++ b/kubernetes/apps/streaming/namespace.yaml
@@ -5,5 +5,7 @@ metadata:
   name: _
   annotations:
     kustomize.toolkit.fluxcd.io/prune: disabled
+    goldilocks.fairwinds.com/vpa-update-mode: Auto
+    goldilocks.fairwinds.com/vpa-resource-policy: '{"containerPolicies":[{"containerName":"*","maxAllowed":{"cpu":"250m","memory":"1Gi"}}]}'
   labels:
-    goldilocks.fairwinds.com/enabled: "true"
+    goldilocks.fairwinds.com/enabled: 'true'

--- a/kubernetes/apps/system-upgrade/namespace.yaml
+++ b/kubernetes/apps/system-upgrade/namespace.yaml
@@ -5,5 +5,7 @@ metadata:
   name: _
   annotations:
     kustomize.toolkit.fluxcd.io/prune: disabled
+    goldilocks.fairwinds.com/vpa-update-mode: Auto
+    goldilocks.fairwinds.com/vpa-resource-policy: '{"containerPolicies":[{"containerName":"*","maxAllowed":{"cpu":"100m","memory":"512Mi"}}]}'
   labels:
-    goldilocks.fairwinds.com/enabled: "true"
+    goldilocks.fairwinds.com/enabled: 'true'

--- a/kubernetes/apps/volsync-system/namespace.yaml
+++ b/kubernetes/apps/volsync-system/namespace.yaml
@@ -5,3 +5,5 @@ metadata:
   name: _
   annotations:
     kustomize.toolkit.fluxcd.io/prune: disabled
+  labels:
+    goldilocks.fairwinds.com/enabled: "true"

--- a/kubernetes/apps/volsync-system/namespace.yaml
+++ b/kubernetes/apps/volsync-system/namespace.yaml
@@ -5,5 +5,7 @@ metadata:
   name: _
   annotations:
     kustomize.toolkit.fluxcd.io/prune: disabled
+    goldilocks.fairwinds.com/vpa-update-mode: Auto
+    goldilocks.fairwinds.com/vpa-resource-policy: '{"containerPolicies":[{"containerName":"*","maxAllowed":{"cpu":"100m","memory":"512Mi"}}]}'
   labels:
-    goldilocks.fairwinds.com/enabled: "true"
+    goldilocks.fairwinds.com/enabled: 'true'


### PR DESCRIPTION
Adds goldilocks label to 5 namespaces that were missing coverage, and enables VPA Auto mode with tiered resource ceilings across all goldilocks-enabled namespaces.

**New namespaces:**
- `crossplane-system` (8 pods, ~2.3GB memory)
- `flux-system` (5 pods)
- `external-secrets` (5 pods)
- `cert-manager` (4 pods)
- `volsync-system` (2 pods)

**VPA Auto mode with tiered ceilings:**
| Tier | CPU | Memory | Namespaces |
|------|-----|--------|------------|
| High | 500m | 2Gi | o11y, ai, storage |
| Medium | 250m | 1Gi | default, crossplane-system, flux-system, network, streaming |
| Low | 100m | 512Mi | cert-manager, external-secrets, volsync-system, knative-serving, argo-system, renovate, actions-runner-system, buildbarn, system-upgrade, ml, kubeflow |

**Context:** cluster pods are heavily imbalanced (k8s-0: 118 pods/84% CPU, k8s-2: 28 pods/20% CPU). Most pods have tiny or zero resource requests so the scheduler piles them on one node. VPA Auto with maxAllowed caps will right-size requests so the scheduler distributes evenly, without risk of runaway growth.

Individual deployments can override with per-deployment annotations if they need more than the namespace ceiling.

**Skipped:** `kube-system` (Talos-managed), `rook-ceph` (not configurable), `openebs-system`/`kserve` (minimal)