### PR TITLE
feat(network): add Tailscale operator + subnet router Connector

### DIFF
--- a/kubernetes/apps/tailscale/kustomization.yaml
+++ b/kubernetes/apps/tailscale/kustomization.yaml
@@ -1,0 +1,13 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: tailscale
+
+components:
+  - ../../components/alerts
+
+resources:
+  - ./namespace.yaml
+  - ./tailscale-operator/ks.yaml
+  - ./tailscale-dns/ks.yaml

--- a/kubernetes/apps/tailscale/namespace.yaml
+++ b/kubernetes/apps/tailscale/namespace.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: _
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
+    goldilocks.fairwinds.com/vpa-update-mode: Auto
+    goldilocks.fairwinds.com/vpa-resource-policy: '{"containerPolicies":[{"containerName":"*","maxAllowed":{"cpu":"250m","memory":"1Gi"}}]}'
+  labels:
+    goldilocks.fairwinds.com/enabled: 'true'

--- a/kubernetes/apps/tailscale/tailscale-dns/app/helmrelease.yaml
+++ b/kubernetes/apps/tailscale/tailscale-dns/app/helmrelease.yaml
@@ -1,0 +1,44 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: k8s-gateway
+spec:
+  interval: 1h
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 3.7.1
+  url: oci://ghcr.io/k8s-gateway/charts/k8s-gateway
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: tailscale-dns
+spec:
+  interval: 1h
+  chartRef:
+    kind: OCIRepository
+    name: k8s-gateway
+  install:
+    crds: CreateReplace
+    remediation:
+      retries: -1
+  upgrade:
+    cleanupOnFail: true
+    crds: CreateReplace
+    remediation:
+      retries: 3
+  values:
+    domain: goyangi.io
+    ttl: 1
+    service:
+      ipFamily: IPv4
+      ipFamilyPolicy: SingleStack
+      loadBalancerClass: tailscale
+      port: 53
+      type: LoadBalancer
+    watchedResources: ["HTTPRoute"]

--- a/kubernetes/apps/tailscale/tailscale-dns/app/kustomization.yaml
+++ b/kubernetes/apps/tailscale/tailscale-dns/app/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml

--- a/kubernetes/apps/tailscale/tailscale-dns/ks.yaml
+++ b/kubernetes/apps/tailscale/tailscale-dns/ks.yaml
@@ -1,0 +1,22 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app tailscale-dns
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: tailscale-operator
+  targetNamespace: tailscale
+  path: ./kubernetes/apps/tailscale/tailscale-dns/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  interval: 1h
+  retryInterval: 2m
+  timeout: 5m

--- a/kubernetes/apps/tailscale/tailscale-operator/app/externalsecret.yaml
+++ b/kubernetes/apps/tailscale/tailscale-operator/app/externalsecret.yaml
@@ -1,0 +1,23 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1beta1.json
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: tailscale-operator
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-connect
+  target:
+    name: tailscale-operator-oauth
+    creationPolicy: Owner
+  data:
+    - secretKey: client_id
+      remoteRef:
+        key: tailscale
+        property: TS_CLIENT_ID
+    - secretKey: client_secret
+      remoteRef:
+        key: tailscale
+        property: TS_CLIENT_SECRET

--- a/kubernetes/apps/tailscale/tailscale-operator/app/helmrelease.yaml
+++ b/kubernetes/apps/tailscale/tailscale-operator/app/helmrelease.yaml
@@ -1,0 +1,53 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: tailscale-operator
+spec:
+  interval: 1h
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 1.96.5
+  url: oci://ghcr.io/home-operations/charts-mirror/tailscale-operator
+  verify:
+    provider: cosign
+    matchOIDCIdentity:
+      - issuer: ^https://token.actions.githubusercontent.com$
+        subject: ^https://github.com/home-operations/charts-mirror.*$
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: tailscale-operator
+spec:
+  interval: 1h
+  chartRef:
+    kind: OCIRepository
+    name: tailscale-operator
+  install:
+    crds: CreateReplace
+    remediation:
+      retries: -1
+  upgrade:
+    cleanupOnFail: true
+    crds: CreateReplace
+    remediation:
+      retries: 3
+  valuesFrom:
+    - kind: Secret
+      name: tailscale-operator-oauth
+      valuesKey: client_id
+      targetPath: oauth.clientId
+    - kind: Secret
+      name: tailscale-operator-oauth
+      valuesKey: client_secret
+      targetPath: oauth.clientSecret
+  values:
+    operatorConfig:
+      hostname: k8s
+    apiServerProxyConfig:
+      mode: "true"

--- a/kubernetes/apps/tailscale/tailscale-operator/app/kustomization.yaml
+++ b/kubernetes/apps/tailscale/tailscale-operator/app/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./externalsecret.yaml
+  - ./helmrelease.yaml

--- a/kubernetes/apps/tailscale/tailscale-operator/connector/connector.yaml
+++ b/kubernetes/apps/tailscale/tailscale-operator/connector/connector.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: tailscale.com/v1alpha1
+kind: Connector
+metadata:
+  name: home-cluster
+spec:
+  hostname: k8s-connector
+  subnetRouter:
+    advertiseRoutes:
+      - 10.42.0.0/16
+      - 10.43.0.0/16
+      - 192.168.69.0/24
+      - 192.168.1.0/24

--- a/kubernetes/apps/tailscale/tailscale-operator/connector/kustomization.yaml
+++ b/kubernetes/apps/tailscale/tailscale-operator/connector/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./connector.yaml

--- a/kubernetes/apps/tailscale/tailscale-operator/ks.yaml
+++ b/kubernetes/apps/tailscale/tailscale-operator/ks.yaml
@@ -1,0 +1,44 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app tailscale-operator
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  targetNamespace: tailscale
+  path: ./kubernetes/apps/tailscale/tailscale-operator/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  interval: 1h
+  retryInterval: 2m
+  timeout: 5m
+  wait: true
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app tailscale-connector
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: tailscale-operator
+  targetNamespace: tailscale
+  path: ./kubernetes/apps/tailscale/tailscale-operator/connector
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  interval: 1h
+  retryInterval: 2m
+  timeout: 5m
+  wait: true


### PR DESCRIPTION
Deploys the Tailscale Kubernetes operator with a Connector that acts as a subnet router, advertising cluster networks to the tailnet.

**Advertised routes:**
- `10.42.0.0/16` — pod CIDR
- `10.43.0.0/16` — service CIDR
- `192.168.69.0/24` — LBIPAM
- `192.168.1.0/24` — LAN

**Auth:** OAuth client credentials from 1Password (`tailscale` item, `TS_CLIENT_ID` + `TS_CLIENT_SECRET` fields).

**Why:** Replaces WireGuard as the transport layer for the work laptop. Tailscale punches through corporate firewalls (Palo Alto GlobalProtect) via DERP relays over HTTPS, which WireGuard cannot do. Once active, chisel on the work laptop connects to the cluster via Tailscale instead of WireGuard.

**Prerequisites:**
1. Create OAuth client at https://login.tailscale.com/admin/settings/oauth — needs `devices:write`, `routes:write` scopes
2. Add `tailscale` item to 1Password kubernetes vault with `TS_CLIENT_ID` and `TS_CLIENT_SECRET` fields
3. Approve subnet routes in Tailscale admin after Connector comes up