### PR TITLE
fix: remove remaining headscale references

### DIFF
--- a/kubernetes/apps/crossplane-system/crossplane/configs/externalsecret.yaml
+++ b/kubernetes/apps/crossplane-system/crossplane/configs/externalsecret.yaml
@@ -62,7 +62,7 @@ spec:
         CLUSTER_SECRET: "{{ .CLUSTER_SECRET }}"
         CLUSTER_TOKEN: "{{ .CLUSTER_TOKEN }}"
         CLUSTER_CA_CRT: "{{ .CLUSTER_CA_CRT }}"
-        TAILSCALE_AUTHKEY: "{{ .TAILSCALE_AUTHKEY }}"
+        TAILSCALE_CLIENT_SECRET: "{{ .TAILSCALE_CLIENT_SECRET }}"
         NODEPOOL_USER_DATA: |
           version: v1alpha1
           machine:
@@ -107,7 +107,7 @@ spec:
                 path: /var/etc/tailscale/auth.env
                 permissions: 0o600
                 content: |
-                  TS_AUTHKEY={{ .TAILSCALE_AUTHKEY }}
+                  TS_AUTHKEY={{ .TAILSCALE_CLIENT_SECRET }}
                   TS_EXTRA_ARGS=--advertise-tags=tag:talos-nodes --accept-routes
           cluster:
             id: {{ .CLUSTER_ID }}

--- a/kubernetes/apps/crossplane-system/crossplane/definitions/composition.yaml
+++ b/kubernetes/apps/crossplane-system/crossplane/definitions/composition.yaml
@@ -127,7 +127,7 @@ spec:
                     kind: ExtensionServiceConfig
                     name: tailscale
                     environment:
-                      - TS_AUTHKEY={{ $spec.tailscaleAuthKey }}
+                      - TS_AUTHKEY={{ $spec.tailscaleClientSecret }}
                       - TS_EXTRA_ARGS=--advertise-tags=tag:talos-nodes --accept-routes
                 tags:
                   - compute-worker

--- a/kubernetes/apps/crossplane-system/crossplane/definitions/definition.yaml
+++ b/kubernetes/apps/crossplane-system/crossplane/definitions/definition.yaml
@@ -55,9 +55,9 @@ spec:
                 clusterSecret:
                   type: string
                   description: Talos cluster secret
-                tailscaleAuthKey:
+                tailscaleClientSecret:
                   type: string
-                  description: Tailscale pre-auth key
+                  description: Tailscale OAuth client secret
                 targetSize:
                   type: integer
                   default: 0

--- a/kubernetes/apps/crossplane-system/crossplane/definitions/prometheusrule.yaml
+++ b/kubernetes/apps/crossplane-system/crossplane/definitions/prometheusrule.yaml
@@ -60,4 +60,4 @@ spec:
             severity: warning
           annotations:
             summary: "Nodepool expects {{ $value }} workers but none are Ready"
-            description: "targetSize is {{ $value }} but no nodepool workers have joined after 5m. Check MIG and Headscale."
+            description: "targetSize is {{ $value }} but no nodepool workers have joined after 5m. Check MIG and Tailscale."

--- a/kubernetes/apps/crossplane-system/crossplane/resources/nodepool.yaml
+++ b/kubernetes/apps/crossplane-system/crossplane/resources/nodepool.yaml
@@ -16,6 +16,6 @@ spec:
   clusterCaCrt: ${CLUSTER_CA_CRT}
   clusterId: ${CLUSTER_ID}
   clusterSecret: ${CLUSTER_SECRET}
-  tailscaleAuthKey: ${TAILSCALE_AUTHKEY}
+  tailscaleClientSecret: ${TAILSCALE_CLIENT_SECRET}
   targetSize: 0
   maxSize: 8

--- a/kubernetes/apps/kube-system/cilium/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/cilium/app/helmrelease.yaml
@@ -11,7 +11,7 @@ spec:
   interval: 1h
   values:
     # NOTE: Divergence from onedr0p/home-ops - disabled because we use tunnel mode
-    # for cross-network nodepool workers (GCP VMs via Headscale/Tailscale)
+    # for cross-network nodepool workers (GCP VMs via Tailscale)
     autoDirectNodeRoutes: false
     ipv6:
       enabled: true
@@ -84,7 +84,7 @@ spec:
     rollOutCiliumPods: true
     # NOTE: Divergence from onedr0p/home-ops - tunnel mode instead of native
     # Required for nodepool workers on different L2 segments (GCP VMs connected
-    # via Headscale). VXLAN encapsulates pod traffic so it traverses tailscale0.
+    # via Tailscale). VXLAN encapsulates pod traffic so it traverses tailscale0.
     routingMode: tunnel
     tunnelProtocol: vxlan
     securityContext:

--- a/kubernetes/mod.just
+++ b/kubernetes/mod.just
@@ -221,7 +221,7 @@ nodepool-teardown:
     kubectl delete xcomputenodepools.home-ops.io nodepool
     just kube nodepool-cleanup
 
-[doc('Clean up stale k8s and Headscale nodes')]
+[doc('Clean up stale k8s burst nodes')]
 nodepool-cleanup:
     #!/usr/bin/env bash
     set -euo pipefail
@@ -234,11 +234,4 @@ nodepool-cleanup:
     else
         echo "No stale k8s nodes"
     fi
-    hs_nodes=$(kubectl exec -n network deploy/headscale -- headscale nodes list --user burst -o json 2>/dev/null | jq -r '.[].id' || true)
-    if [[ -n "$hs_nodes" ]]; then
-        for id in $hs_nodes; do
-            kubectl exec -n network deploy/headscale -- headscale nodes delete -i "$id" --force
-        done
-    else
-        echo "No stale Headscale nodes"
-    fi
+    # Tailscale ephemeral nodes auto-expire — no manual cleanup needed


### PR DESCRIPTION
Cleans up leftover headscale references after Tailscale migration.

**Changes:**
- Crossplane prometheusrule: Headscale → Tailscale in alert description
- Cilium helmrelease: update comments to reference Tailscale only
- justfile nodepool-cleanup: remove headscale node deletion (Tailscale ephemeral nodes auto-expire)

Crossplane configs (composition, definition, externalsecret, nodepool) were already migrated on main.