### PR TITLE
feat(webhook): add opencode event forwarding

### DIFF
--- a/kubernetes/apps/ai/openclaw/webhook/externalsecret.yaml
+++ b/kubernetes/apps/ai/openclaw/webhook/externalsecret.yaml
@@ -13,6 +13,7 @@ spec:
       data:
         OPENCLAW_HOOKS_TOKEN: "{{ .OPENCLAW_HOOKS_TOKEN }}"
         GITHUB_WEBHOOK_SECRET: "{{ .GITHUB_WEBHOOK_SECRET }}"
+        OPENCODE_WEBHOOK_TOKEN: "{{ .OPENCODE_WEBHOOK_TOKEN }}"
   dataFrom:
     - extract:
         key: openclaw-webhook

--- a/kubernetes/apps/ai/openclaw/webhook/kustomization.yaml
+++ b/kubernetes/apps/ai/openclaw/webhook/kustomization.yaml
@@ -10,6 +10,7 @@ configMapGenerator:
     files:
       - hooks.yaml=./resources/hooks.yaml
       - github.sh=./resources/github.sh
+      - opencode.sh=./resources/opencode.sh
 generatorOptions:
   disableNameSuffixHash: true
   annotations:

--- a/kubernetes/apps/ai/openclaw/webhook/resources/hooks.yaml
+++ b/kubernetes/apps/ai/openclaw/webhook/resources/hooks.yaml
@@ -17,3 +17,11 @@
       parameter:
         source: header
         name: X-Hub-Signature-256
+- id: 'opencode-{{ getenv "OPENCODE_WEBHOOK_TOKEN" }}'
+  execute-command: /config/opencode.sh
+  command-working-directory: /tmp
+  pass-body-to-command: true
+  pass-environment-to-command:
+    - envname: OPENCLAW_HOOKS_TOKEN
+      source: string
+      name: '{{ getenv "OPENCLAW_HOOKS_TOKEN" }}'

--- a/kubernetes/apps/ai/openclaw/webhook/resources/opencode.sh
+++ b/kubernetes/apps/ai/openclaw/webhook/resources/opencode.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${OPENCLAW_HOOKS_TOKEN:?}"
+API_URL="${OPENCODE_API_URL:-http://mac.internal:4096}"
+STATE_DIR="/tmp/opencode-webhook"
+
+PAYLOAD=$(cat)
+
+EVENT_TYPE=$(echo "${PAYLOAD}" | jq -r '.event.type // ""')
+[[ "${EVENT_TYPE}" != "message.updated" ]] && exit 0
+
+ROLE=$(echo "${PAYLOAD}" | jq -r '.event.properties.info.role // ""')
+[[ "${ROLE}" != "assistant" ]] && exit 0
+
+COMPLETED=$(echo "${PAYLOAD}" | jq -r '.event.properties.info.time.completed // ""')
+[[ -z "${COMPLETED}" || "${COMPLETED}" == "null" ]] && exit 0
+
+MSG_ID=$(echo "${PAYLOAD}" | jq -r '.event.properties.info.id // ""')
+SESSION_ID=$(echo "${PAYLOAD}" | jq -r '.event.properties.info.sessionID // ""')
+[[ -z "${MSG_ID}" || -z "${SESSION_ID}" ]] && exit 0
+
+mkdir -p "${STATE_DIR}"
+find "${STATE_DIR}" -type f -mmin +10 -delete 2>/dev/null || true
+[[ -e "${STATE_DIR}/${MSG_ID}" ]] && exit 0
+touch "${STATE_DIR}/${MSG_ID}"
+
+SESSION_JSON=$(curl -sf "${API_URL}/session/${SESSION_ID}" || echo '{}')
+TITLE=$(echo "${SESSION_JSON}" | jq -r '.title // ""')
+[[ ! "${TITLE}" =~ ^HAWOW: ]] && exit 0
+
+MESSAGE="OpenCode session ${TITLE} finished (sessionID: ${SESSION_ID}). Read the last assistant message and continue."
+
+curl -sf -X POST http://openclaw.ai.svc.cluster.local:18789/hooks/agent \
+    -H "Authorization: Bearer ${OPENCLAW_HOOKS_TOKEN}" \
+    -H "Content-Type: application/json" \
+    -d "$(jq -n --arg msg "${MESSAGE}" '{message: $msg, name: "OpenCode"}')"


### PR DESCRIPTION
## Summary

- Adds an `opencode` hook alongside the existing `github` one in the openclaw webhook
- Forwards dtinth/opencode-webhook `message.updated` events to the openclaw agent so Hawow wakes up on finished assistant responses instead of polling
- Auth is a path-embedded shared secret (`OPENCODE_WEBHOOK_TOKEN`) via the templated hook id, since the plugin cannot set headers or sign the body
- Filters for `event.type == message.updated`, `role == assistant`, `time.completed != null`, and a session title matching `^HAWOW:` fetched from the OpenCode API
- Dedupes per message id under `/tmp/opencode-webhook` with a 10 min TTL sweep

## 1Password

Before merging, add a new field `OPENCODE_WEBHOOK_TOKEN` to the existing `openclaw-webhook` item in the `kubernetes` vault. Value should be a random high-entropy string (the path secret). The opencode plugin on mac.internal will be configured to POST to `https://webhook.goyangi.io/hooks/opencode-<token>`.

`OPENCODE_API_URL` falls back to `http://mac.internal:4096` inside the script, so no secret/env needed unless the ExternalName is wired up later.

## Testing

Synthetic payload against the service:

```bash
TOKEN=$(op item get openclaw-webhook --field OPENCODE_WEBHOOK_TOKEN --vault kubernetes)
curl -sf -X POST "https://webhook.goyangi.io/hooks/opencode-${TOKEN}" \
  -H "Content-Type: application/json" \
  -d '{
    "timestamp": 0,
    "directory": "/tmp",
    "worktree": "/tmp",
    "event": {
      "type": "message.updated",
      "properties": {
        "info": {
          "id": "msg_test_1",
          "sessionID": "ses_test_1",
          "role": "assistant",
          "time": {"created": 1, "completed": 2}
        }
      }
    }
  }'
```

Inspect filter decisions in the webhook pod:

```bash
kubectl -n ai logs deploy/openclaw-webhook -c app -f
```

Expect non-HAWOW sessions, non-assistant roles, and duplicate message ids to exit 0 without forwarding. A matching payload should produce a POST to `openclaw.ai.svc.cluster.local:18789/hooks/agent`.

## Not in scope

- Installing the opencode plugin on mac.internal (done separately)
- Changes to the existing `github` hook