### PR TITLE
chore(talos): enable NVMe APST for thermal mgmt

### DIFF
--- a/talos/schematic.yaml.j2
+++ b/talos/schematic.yaml.j2
@@ -10,6 +10,7 @@ customization:
     - intel_iommu=on # PCI Passthrough
     - iommu=pt # PCI Passthrough
     - mitigations=off # Less security, faster puter
+    - nvme_core.default_ps_max_latency_us=100000 # Enable NVMe APST for idle thermal management
     - pcie_aspm=off # Disable PCIe ASPM
     - security=none # Less security, faster puter
     - talos.auditd.disabled=1 # Less security, faster puter


### PR DESCRIPTION
## Summary

Add `nvme_core.default_ps_max_latency_us=100000` to the Talos schematic's `extraKernelArgs`. This allows the NVMe core driver to place Micron 7450 drives into autonomous low-power states (up to PS3, ~5W, ~10ms exit latency) during idle gaps between Ceph OSD bursts. The active IO path is unchanged; the drive returns to PS0 (8.25W) on demand.

The `100000` µs (100ms) cap intentionally excludes the deepest states (PS4) to keep worst-case first-IO latency well under typical OSD timeouts.

## Why

`SmartDeviceTestFailed` + `SmartDeviceCriticalWarning` alerts have been firing on `k8s-1` nvme0. SMART data shows the drive is physically healthy and the warning is thermal only:

| Metric | Value |
|---|---|
| Model | Micron_7450_MTFDKBA960TFR (enterprise, 960 GB) |
| Critical Warning byte | `0x02` (bit 1 = thermal only, not reliability/spare) |
| Percentage Used | 0 % |
| Available Spare | 100 % |
| Media and Data Integrity Errors | 0 |
| Power On Hours | 3136 |
| Warning Comp Temp Time | 66857 min (~35 % of drive life above 77 °C) |
| Sensor 1 (composite/controller) | 95 °C |
| Sensor 2 | 86 °C |

Chassis airflow cannot be improved mechanically, so the fix is to reduce idle power draw and let the controller cool between IO bursts.

## Changes

- `talos/schematic.yaml.j2`: append `nvme_core.default_ps_max_latency_us=100000` to `customization.extraKernelArgs`.

Placed in the schematic rather than `machine.install.extraKernelArgs` to match the existing pattern where all kernel args live in one place.

## Rollout plan

This is a schematic change, so it takes effect via `talosctl upgrade` (new installer image), not plain `apply-config`.

1. Regenerate the schematic ID and update the installer image reference:
   ```
   just talos gen-schematic-id
   ```
   Then update `machine.install.image` in `talos/machineconfig.yaml.j2` to the new schematic hash if it differs, commit that separately if needed.
2. Roll the control-plane one node at a time to preserve etcd quorum:
   ```
   just talos upgrade-node k8s-0
   # wait for node Ready and etcd healthy
   just talos upgrade-node k8s-1
   # wait for node Ready and etcd healthy
   just talos upgrade-node k8s-2
   ```
3. Verify APST is active on each node after reboot:
   ```
   talosctl -n <node> read /sys/class/nvme/nvme0/power/pm_qos_latency_tolerance_us
   # expect: 100000
   ```
   And confirm the drive transitions states under idle via `nvme get-feature -f 0x0c -H` (requires the `siderolabs/nvme-cli` extension, not added here).
4. Watch composite temperature trend down on Grafana / `node_nvme_temperature_celsius`.

## Rollback

1. Remove the `nvme_core.default_ps_max_latency_us=100000` line from `talos/schematic.yaml.j2`.
2. Regenerate schematic ID, update installer image ref.
3. `just talos upgrade-node` each control plane in turn.

## Notes

- APST is kernel-level — no `siderolabs/nvme-cli` extension needed for the feature itself.
- `pcie_aspm=off` is already set in the schematic. That only disables PCIe link power management, not NVMe device power states, so there's no conflict.
- Safe default for Ceph OSDs: PS3 exit latency (~10 ms) is well below any OSD timeout.