### PR TITLE
chore(lakekeeper): bump memory limit to 512Mi

### DIFF
--- a/kubernetes/apps/storage/lakekeeper/app/helmrelease.yaml
+++ b/kubernetes/apps/storage/lakekeeper/app/helmrelease.yaml
@@ -58,9 +58,9 @@ spec:
             resources:
               requests:
                 cpu: 10m
-                memory: 50Mi
-              limits:
                 memory: 128Mi
+              limits:
+                memory: 512Mi
     defaultPodOptions:
       securityContext:
         runAsNonRoot: true


### PR DESCRIPTION
## Problem

Lakekeeper pod was OOMKilling repeatedly:
- 39 restarts over 4d23h
- Last state: `terminated / OOMKilled / exitCode 137` at 2026-05-04T09:00:04Z
- Current limits: `requests.memory: 50Mi`, `limits.memory: 128Mi`

## Change

- `requests.memory`: 50Mi → 128Mi
- `limits.memory`: 128Mi → 512Mi

## Why 512Mi

Lakekeeper (Iceberg catalog) keeps table metadata + request-handling buffers in memory. 128Mi is too tight for anything but idle. 512Mi matches the upstream chart's recommended floor and leaves headroom for spikes during snapshot operations.

## Verification

- Flux will reconcile on merge
- Pod should come up with the new limits and stop cycling
- If it's still OOMing at 512Mi we've got a real leak, not a sizing issue

## Reviewer

@solanyn