### PR TITLE
fix: remove duplicate instance.httpRoute from flux-operator

### DIFF
--- a/kubernetes/apps/flux-system/flux-operator/app/helmrelease.yaml
+++ b/kubernetes/apps/flux-system/flux-operator/app/helmrelease.yaml
@@ -21,14 +21,5 @@ spec:
             sectionName: https
         hostnames:
           - flux.goyangi.io
-    instance:
-      httpRoute:
-        enabled: true
-        hostnames:
-          - flux.goyangi.io
-        parentRefs:
-          - name: envoy-internal
-            namespace: network
-            sectionName: https
     serviceMonitor:
       create: true


### PR DESCRIPTION
The `web.httpRoute` block already configures the HTTPRoute via the flux-operator chart. The `instance.httpRoute` block was added erroneously in #3864 and would create a duplicate HTTPRoute resource.

This removes the duplicate, leaving only the correct `web.httpRoute` configuration.