### PR TITLE
feat: add grafana image mirror admission policy

### DIFF
--- a/kubernetes/apps/o11y/grafana/instance/kustomization.yaml
+++ b/kubernetes/apps/o11y/grafana/instance/kustomization.yaml
@@ -12,3 +12,4 @@ resources:
   - ./externalsecret-influxdb.yaml
   - ./grafanadashboard-health.yaml
   - ./grafanadashboard-capacity.yaml
+  - ./mutatingadmissionpolicy.yaml

--- a/kubernetes/apps/o11y/grafana/instance/mutatingadmissionpolicy.yaml
+++ b/kubernetes/apps/o11y/grafana/instance/mutatingadmissionpolicy.yaml
@@ -1,0 +1,48 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/refs/heads/master/v1.36.0/mutatingadmissionpolicybinding-admissionregistration-v1.json
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingAdmissionPolicyBinding
+metadata:
+  name: grafana-image-mirror
+spec:
+  policyName: grafana-image-mirror
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/refs/heads/master/v1.36.0/mutatingadmissionpolicy-admissionregistration-v1.json
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingAdmissionPolicy
+metadata:
+  name: grafana-image-mirror
+spec:
+  matchConstraints:
+    resourceRules:
+      - apiGroups:
+          - apps
+        apiVersions:
+          - v1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - deployments
+  matchConditions:
+    - name: is-grafana-deployment
+      expression: >-
+        object.metadata.name == "grafana-deployment"
+    - name: has-docker-io-grafana-image
+      expression: >-
+        object.spec.template.spec.containers.exists(c,
+          c.image.startsWith("docker.io/grafana/")
+        )
+  failurePolicy: Fail
+  reinvocationPolicy: IfNeeded
+  mutations:
+    - patchType: JSONPatch
+      jsonPatch:
+        expression: >-
+          [
+            JSONPatch{
+              op: "replace",
+              path: "/spec/template/spec/containers/0/image",
+              value: "mirror.gcr.io/grafana/" + object.spec.template.spec.containers[0].image.replace("docker.io/grafana/", "")
+            }
+          ]


### PR DESCRIPTION
Adds a native `MutatingAdmissionPolicy` that rewrites `docker.io/grafana/*` images to `mirror.gcr.io/grafana/*` at admission time for the grafana deployment.

- No webhook pod needed — uses CEL-based native admission (k8s 1.32+)
- Avoids Docker Hub anonymous pull rate limits (100 pulls/6h)
- `mirror.gcr.io` is faster and has no rate limits (Google CDN)
- Only targets the `grafana-deployment` deployment, no blast radius