### PR TITLE
fix: use v1beta1 for MutatingAdmissionPolicy

### DIFF
--- a/kubernetes/apps/o11y/grafana/instance/mutatingadmissionpolicy.yaml
+++ b/kubernetes/apps/o11y/grafana/instance/mutatingadmissionpolicy.yaml
@@ -1,14 +1,14 @@
 ---
-# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/refs/heads/master/v1.36.0/mutatingadmissionpolicybinding-admissionregistration-v1.json
-apiVersion: admissionregistration.k8s.io/v1
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/refs/heads/master/v1.35.0/mutatingadmissionpolicybinding-admissionregistration-v1beta1.json
+apiVersion: admissionregistration.k8s.io/v1beta1
 kind: MutatingAdmissionPolicyBinding
 metadata:
   name: grafana-image-mirror
 spec:
   policyName: grafana-image-mirror
 ---
-# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/refs/heads/master/v1.36.0/mutatingadmissionpolicy-admissionregistration-v1.json
-apiVersion: admissionregistration.k8s.io/v1
+# yaml-language-server: $schema=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/refs/heads/master/v1.35.0/mutatingadmissionpolicy-admissionregistration-v1beta1.json
+apiVersion: admissionregistration.k8s.io/v1beta1
 kind: MutatingAdmissionPolicy
 metadata:
   name: grafana-image-mirror


### PR DESCRIPTION
Our cluster is on k8s 1.35 where MutatingAdmissionPolicy is at `v1beta1`. It graduates to `v1` in 1.36.

Fixes the flux reconciliation failure:
```
no matches for kind "MutatingAdmissionPolicy" in version "admissionregistration.k8s.io/v1"
```