### PR TITLE
feat(talos): upgrade to v1.13.0

### DIFF
--- a/kubernetes/apps/system-upgrade/tuppr/upgrades/talosupgrade.yaml
+++ b/kubernetes/apps/system-upgrade/tuppr/upgrades/talosupgrade.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   talos:
     # renovate: datasource=docker depName=ghcr.io/siderolabs/installer
-    version: v1.12.7
+    version: v1.13.0
   policy:
     rebootMode: powercycle
   healthChecks:

--- a/talos/machineconfig.yaml.j2
+++ b/talos/machineconfig.yaml.j2
@@ -50,7 +50,7 @@ machine:
   install:
     diskSelector:
       model: SAMSUNG MZ7LM960
-    image: factory.talos.dev/metal-installer/d82b101c9ff537b6b6adc91b3b55abdc5a4f647e79852172575b0764e12e137b:v1.12.7
+    image: factory.talos.dev/metal-installer/3b73f15bf9015a0e3884482abb336c43c9a4c4ed021af3410c61852af461f3e7:v1.13.0
     wipe: false
   kernel:
     modules:

--- a/talos/schematic.yaml.j2
+++ b/talos/schematic.yaml.j2
@@ -12,6 +12,7 @@ customization:
     - mitigations=off # Less security, faster puter
     - pcie_aspm=off # Disable PCIe ASPM
     - security=none # Less security, faster puter
+    - sysctl.kernel.kexec_load_disabled=1 # Disable kexec for safer upgrades
     - talos.auditd.disabled=1 # Less security, faster puter
     - i915.enable_guc=3 # Meteor Lake CPU & Intel iGPU
   systemExtensions:
@@ -22,4 +23,3 @@ customization:
       - siderolabs/nfsrahead # NFS Performance
       - siderolabs/tailscale # Tailscale VPN
       - siderolabs/util-linux-tools # Disk utilities
-      - siderolabs/tailscale # Tailscale


### PR DESCRIPTION
## Talos v1.12.7 → v1.13.0

### Changes
- Talos installer bumped to v1.13.0 (kernel 6.18.24, Clang-built with ThinLTO)
- Added `sysctl.kernel.kexec_load_disabled=1` — disables kexec so upgrades always powercycle (safer, matches tuppr `rebootMode: powercycle`)
- Removed duplicate `siderolabs/tailscale` extension entry in schematic
- New schematic ID generated for updated kernel args + extensions

### Upgrade path
Tuppr handles the rolling upgrade automatically:
1. Waits for VolSync replication sources to finish syncing
2. Waits for Ceph health OK
3. Upgrades one node at a time with powercycle reboot

### What's new in Talos 1.13
- Clang-built kernel with ThinLTO (performance)
- Linux 6.18.24
- Tightened /proc/PID/mem defaults
- CDI-by-default for container device injection
- Node image APIs with pull progress

### Pre-merge checklist
- [ ] VolSync snapshot (`just kube snapshot`)
- [ ] CNPG backup (`just kube cnpg-backup`)
- [ ] Verify Ceph health OK