### PR TITLE
fix(o11y): restore alertmanager pushover notifications

### DIFF
--- a/kubernetes/apps/o11y/kube-prometheus-stack/app/alertmanagerconfig.yaml
+++ b/kubernetes/apps/o11y/kube-prometheus-stack/app/alertmanagerconfig.yaml
@@ -1,0 +1,99 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/monitoring.coreos.com/alertmanagerconfig_v1alpha1.json
+apiVersion: monitoring.coreos.com/v1alpha1
+kind: AlertmanagerConfig
+metadata:
+  name: alertmanager
+spec:
+  route:
+    receiver: pushover
+    repeatInterval: 12h
+    routes:
+      - receiver: blackhole
+        matchers:
+          - name: alertname
+            value: InfoInhibitor
+            matchType: =
+      - receiver: heartbeat
+        groupInterval: 2m
+        groupWait: 0s
+        repeatInterval: 2m30s
+        matchers:
+          - name: alertname
+            value: Watchdog
+            matchType: =
+      - receiver: pushover
+        matchers:
+          - name: severity
+            value: critical
+            matchType: =
+    groupBy:
+      - alertname
+      - cluster
+      - job
+    groupInterval: 5m
+    groupWait: 1m
+
+  inhibitRules:
+    - equal:
+        - alertname
+        - namespace
+      sourceMatch:
+        - name: severity
+          value: critical
+          matchType: =
+      targetMatch:
+        - name: severity
+          value: warning
+          matchType: =
+
+  receivers:
+    - name: blackhole
+    - name: heartbeat
+      webhookConfigs:
+        - urlSecret:
+            name: alertmanager-secret
+            key: ALERTMANAGER_HEARTBEAT_URL
+        - url: http://gatus.o11y.svc.cluster.local/api/v1/endpoints/monitoring_alertmanager/external?success=true
+          httpConfig:
+            authorization:
+              type: Bearer
+              credentials:
+                name: alertmanager-secret
+                key: GATUS_HEARTBEAT_TOKEN
+    - name: pushover
+      pushoverConfigs:
+        - html: true
+          message: |-
+            {{- range .Alerts }}
+              {{- if ne .Annotations.description "" }}
+                {{ .Annotations.description }}
+              {{- else if ne .Annotations.summary "" }}
+                {{ .Annotations.summary }}
+              {{- else if ne .Annotations.message "" }}
+                {{ .Annotations.message }}
+              {{- else }}
+                Alert description not available
+              {{- end }}
+              {{- if gt (len .Labels.SortedPairs) 0 }}
+                <small>
+                  {{- range .Labels.SortedPairs }}
+                    <b>{{ .Name }}:</b> {{ .Value }}
+                  {{- end }}
+                </small>
+              {{- end }}
+            {{- end }}
+          priority: |-
+            {{ if eq .Status "firing" }}1{{ else }}0{{ end }}
+          sendResolved: true
+          sound: gamelan
+          title: >-
+            [{{ .Status | toUpper }}{{ if eq .Status "firing" }}:{{ .Alerts.Firing | len }}{{ end }}] {{ .CommonLabels.alertname }}
+          ttl: 86400s
+          token:
+            name: alertmanager-secret
+            key: ALERTMANAGER_PUSHOVER_TOKEN
+          userKey:
+            name: alertmanager-secret
+            key: PUSHOVER_USER_KEY
+          urlTitle: View in Alertmanager

--- a/kubernetes/apps/o11y/kube-prometheus-stack/app/externalsecret.yaml
+++ b/kubernetes/apps/o11y/kube-prometheus-stack/app/externalsecret.yaml
@@ -1,0 +1,26 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: alertmanager
+spec:
+  refreshInterval: 5m
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: alertmanager-secret
+    template:
+      data:
+        ALERTMANAGER_HEARTBEAT_URL: "{{ .ALERTMANAGER_HEARTBEAT_URL }}"
+        ALERTMANAGER_PUSHOVER_TOKEN: "{{ .ALERTMANAGER_PUSHOVER_TOKEN }}"
+        PUSHOVER_USER_KEY: "{{ .PUSHOVER_USER_KEY }}"
+        GATUS_HEARTBEAT_TOKEN: "{{ .GATUS_HEARTBEAT_TOKEN }}"
+  dataFrom:
+    - extract:
+        key: alertmanager
+    - extract:
+        key: pushover
+    - extract:
+        key: gatus

--- a/kubernetes/apps/o11y/kube-prometheus-stack/app/kustomization.yaml
+++ b/kubernetes/apps/o11y/kube-prometheus-stack/app/kustomization.yaml
@@ -3,5 +3,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - ./alertmanagerconfig.yaml
+  - ./externalsecret.yaml
   - ./ocirepository.yaml
   - ./helmrelease.yaml


### PR DESCRIPTION
AlertmanagerConfig and ExternalSecret were lost during the victoria-metrics → kube-prometheus-stack migration (commit e6ca72aca, May 14). All alerts have been routing to the null receiver since then.

## Changes
- Restore `alertmanagerconfig.yaml` — pushover for critical, heartbeat webhook for Watchdog/Gatus, blackhole for InfoInhibitor
- Restore `externalsecret.yaml` — pulls from 1Password items: `alertmanager`, `pushover`, `gatus`
- Update `kustomization.yaml` to include both new files

## Verified
- 1Password items exist: `alertmanager` (ALERTMANAGER_HEARTBEAT_URL, ALERTMANAGER_PUSHOVER_TOKEN), `pushover` (PUSHOVER_USER_KEY), `gatus` (GATUS_HEARTBEAT_TOKEN)
- ClusterSecretStore `onepassword` is active
- Alertmanager pod is running (2/2, 4d14h uptime)
- 38 alerts currently firing, all going to null receiver
- Config matches pre-migration state with updated service reference (gatus.o11y.svc instead of gatus.observability.svc)