### PR TITLE
fix(o11y): silence SmartDeviceCriticalWarning for nvme0

### DIFF
--- a/kubernetes/apps/o11y/silence-operator/silences/silences.yaml
+++ b/kubernetes/apps/o11y/silence-operator/silences/silences.yaml
@@ -150,3 +150,17 @@ spec:
       value: KubeDeploymentReplicasMismatch
     - name: namespace
       value: kubeflow
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/observability.giantswarm.io/silence_v1alpha2.json
+# TODO: remove when k8s-1 NVMe replaced or thermals resolved
+apiVersion: monitoring.giantswarm.io/v1alpha1
+kind: Silence
+metadata:
+  name: smart-device-critical-warning-nvme0
+  namespace: o11y
+spec:
+  matchers:
+    - name: alertname
+      value: SmartDeviceCriticalWarning
+    - name: device
+      value: nvme0


### PR DESCRIPTION
Silences the `SmartDeviceCriticalWarning` alert for all nvme0 devices (k8s-1 NVMe thermal issue).

Metrics still collected — can check SMART health via Grafana/PromQL periodically.

TODO: remove when NVMe replaced or thermals resolved.