### PR TITLE
openclaw: switch web search to brave

### DIFF
--- a/kubernetes/apps/ai/openclaw/app/externalsecret.yaml
+++ b/kubernetes/apps/ai/openclaw/app/externalsecret.yaml
@@ -338,7 +338,7 @@ spec:
               "web": {
                 "search": {
                   "enabled": true,
-                  "provider": "tavily"
+                  "provider": "brave"
                 }
               },
               "media": {


### PR DESCRIPTION
Switches web search provider from tavily to brave. Tavily API key works but the tool isn't being exposed in sandbox sessions. Brave plugin is already configured with a working key.