### PR TITLE
feat(renovate): add forgejo nix-darwin job

### DIFF
--- a/kubernetes/apps/renovate/renovate-operator/jobs/externalsecret-forgejo.yaml
+++ b/kubernetes/apps/renovate/renovate-operator/jobs/externalsecret-forgejo.yaml
@@ -1,0 +1,19 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: renovate-forgejo
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: renovate-forgejo-secret
+    creationPolicy: Owner
+    template:
+      data:
+        TOKEN: "{{ .FORGEJO_TOKEN }}"
+  dataFrom:
+    - extract:
+        key: forgejo

--- a/kubernetes/apps/renovate/renovate-operator/jobs/kustomization.yaml
+++ b/kubernetes/apps/renovate/renovate-operator/jobs/kustomization.yaml
@@ -3,4 +3,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./externalsecret.yaml
+  - ./externalsecret-forgejo.yaml
   - ./renovatejob.yaml
+  - ./renovatejob-forgejo.yaml

--- a/kubernetes/apps/renovate/renovate-operator/jobs/renovatejob-forgejo.yaml
+++ b/kubernetes/apps/renovate/renovate-operator/jobs/renovatejob-forgejo.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: renovate-operator.mogenius.com/v1alpha1
+kind: RenovateJob
+metadata:
+  name: forgejo
+spec:
+  schedule: "30 * * * *"
+  provider:
+    name: gitea
+  secretRef: renovate-forgejo-secret
+  image: ghcr.io/renovatebot/renovate:latest
+  parallelism: 1
+  extraEnv:
+    - name: LOG_LEVEL
+      value: debug
+    - name: RENOVATE_PLATFORM
+      value: gitea
+    - name: RENOVATE_ENDPOINT
+      value: https://forgejo.goyangi.io
+    - name: RENOVATE_PLATFORM_COMMIT
+      value: "true"
+    - name: RENOVATE_AUTODISCOVER
+      value: "false"
+    - name: RENOVATE_REPOSITORIES
+      value: '["andrew/nix-darwin"]'


### PR DESCRIPTION
Adds Renovate operator job targeting `andrew/nix-darwin` on Forgejo.

## Changes
- New `RenovateJob` with gitea provider pointing at forgejo.goyangi.io
- New `ExternalSecret` pulling FORGEJO_TOKEN from 1Password
- Automerge enabled (branch strategy, no PR noise)

## Notes
- `renovate.json` already pushed to nix-darwin repo
- Will maintain `flake.lock` weekly + automerge all updates