### PR TITLE
fix: rename onepassword-secret to onepassword-connect-secret

### DIFF
--- a/bootstrap/resources.yaml.j2
+++ b/bootstrap/resources.yaml.j2
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: onepassword-secret
+  name: onepassword-connect-secret
   namespace: external-secrets
 stringData:
   1password-credentials.json: op://kubernetes/1password/OP_CREDENTIALS_JSON

--- a/kubernetes/apps/external-secrets/onepassword/app/clustersecretstore.yaml
+++ b/kubernetes/apps/external-secrets/onepassword/app/clustersecretstore.yaml
@@ -13,6 +13,6 @@ spec:
       auth:
         secretRef:
           connectTokenSecretRef:
-            name: onepassword-secret
+            name: onepassword-connect-secret
             namespace: external-secrets
             key: token

--- a/kubernetes/apps/external-secrets/onepassword/app/externalsecret.yaml
+++ b/kubernetes/apps/external-secrets/onepassword/app/externalsecret.yaml
@@ -9,7 +9,7 @@ spec:
     kind: ClusterSecretStore
     name: onepassword-connect
   target:
-    name: onepassword-secret
+    name: onepassword-connect-secret
     template:
       data:
         1password-credentials.json: "{{ .OP_CREDENTIALS_JSON }}"


### PR DESCRIPTION
The HelmRelease uses `{{ .Release.Name }}-secret` which resolves to `onepassword-connect-secret`, but bootstrap and ClusterSecretStore referenced `onepassword-secret`. This mismatch caused the connect pod to fail with `CreateContainerConfigError` when the original secret was cleaned up.

**Changes:**
- `bootstrap/resources.yaml.j2`: renamed secret to `onepassword-connect-secret`
- `clustersecretstore.yaml`: updated `connectTokenSecretRef.name`
- `externalsecret.yaml`: updated target secret name

**Impact:** Fixes Grafana Flux kustomization health check failure (1Password Connect down for 2.5 days).