### PR TITLE
fix(influxdb): bypass broken entrypoint, run influxd directly

### DIFF
--- a/.github/workflows/image-pull.yaml
+++ b/.github/workflows/image-pull.yaml
@@ -32,95 +32,51 @@ jobs:
     needs: filter
     name: Image Pull - Extract Images
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        branch:
-          - default
-          - pull
-      fail-fast: false
     outputs:
-      default: ${{ steps.extract.outputs.default }}
-      pull: ${{ steps.extract.outputs.pull }}
+      images: ${{ steps.extract.outputs.images }}
     steps:
-      - name: Generate Token
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
-        id: app-token
-        with:
-          app-id: ${{ secrets.BOT_APP_ID }}
-          private-key: ${{ secrets.BOT_APP_PRIVATE_KEY }}
-
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
+          fetch-depth: 0
           persist-credentials: false
-          ref: ${{ matrix.branch == 'default' && github.event.repository.default_branch || '' }}
-          token: ${{ steps.app-token.outputs.token }}
 
-      - name: Gather Images
-        uses: docker://ghcr.io/allenporter/flux-local:v8.2.0
-        env:
-          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+      - name: Setup Mise
+        uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
         with:
-          args: >-
-            get cluster
-            --all-namespaces
-            --path /github/workspace/kubernetes/flux/cluster
-            --enable-images
-            --only-images
-            --output json
-            --output-file images.json
+          cache: false
+          tool_versions: |
+            github:home-operations/flate 0.2.12
 
       - name: Extract Images
         id: extract
-        run: |-
-          echo "${{ matrix.branch }}=$(jq --compact-output '.' images.json)" >> $GITHUB_OUTPUT
-
-          echo '## Branch ${{ matrix.branch }} images' >> $GITHUB_STEP_SUMMARY
-          echo '```json' >> $GITHUB_STEP_SUMMARY
-          jq '.' images.json >> $GITHUB_STEP_SUMMARY
-          echo '```' >> $GITHUB_STEP_SUMMARY
-
-  diff:
-    if: ${{ needs.extract.outputs.default != needs.extract.outputs.pull }}
-    needs: extract
-    name: Image Pull - Diff Images
-    runs-on: ubuntu-latest
-    outputs:
-      images: ${{ steps.diff.outputs.images }}
-    steps:
-      - name: Diff Images
-        id: diff
-        run: |-
-          images=$(jq --compact-output --null-input \
-              --argjson f1 '${{ needs.extract.outputs.default }}' \
-              --argjson f2 '${{ needs.extract.outputs.pull }}' \
-              '$f2 - $f1' \
-          )
-          echo "images=${images}" >> $GITHUB_OUTPUT
-
-          echo '## New images to Pull' >> $GITHUB_STEP_SUMMARY
-          echo '```json' >> $GITHUB_STEP_SUMMARY
-          echo $images | jq >> $GITHUB_STEP_SUMMARY
-          echo '```' >> $GITHUB_STEP_SUMMARY
+        run: |
+          echo 'images<<EOF' >> $GITHUB_OUTPUT
+          flate diff images -p ./kubernetes/flux/cluster -o json >> $GITHUB_OUTPUT
+          echo 'EOF' >> $GITHUB_OUTPUT
 
   pull:
-    if: ${{ needs.diff.outputs.images != '[]' }}
-    needs: diff
+    if: ${{ needs.extract.outputs.images != '[]' }}
+    needs: extract
     name: Image Pull - Pull Images
     runs-on: home-ops-runner
     strategy:
       matrix:
-        image: ${{ fromJSON(needs.diff.outputs.images) }}
+        image: ${{ fromJSON(needs.extract.outputs.images) }}
       max-parallel: 4
       fail-fast: false
-    env:
-      MATRIX_IMAGE: ${{ matrix.image }}
     steps:
-      - name: Install talosctl
-        run: curl -fsSL https://raw.githubusercontent.com/siderolabs/talos/b412ffdbc29d77a81aed88be62f21bc2999afcde/website/static/install | sh
+      - name: Setup Mise
+        uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
+        with:
+          cache: false
+          tool_versions: |
+            talosctl latest
 
       - name: Pull Image
-        run: talosctl --nodes $NODE image pull "${MATRIX_IMAGE}"
+        env:
+          IMAGE: ${{ matrix.image }}
+        run: talosctl --nodes "$NODE" image pull "$IMAGE"
 
   success:
     if: ${{ !cancelled() }}
@@ -134,4 +90,6 @@ jobs:
 
       - name: All jobs passed or skipped?
         if: ${{ !(contains(needs.*.result, 'failure')) }}
-        run: echo "All jobs passed or skipped" && echo "${{ toJSON(needs.*.result) }}"
+        env:
+          RESULTS: ${{ toJSON(needs.*.result) }}
+        run: echo "All jobs passed or skipped" && echo "$RESULTS"

--- a/.github/workflows/tag.yaml
+++ b/.github/workflows/tag.yaml
@@ -5,25 +5,37 @@ name: Tag
 on:
   workflow_dispatch:
   schedule:
-    - cron: "0 0 1 * *"
+    - cron: 0 0 1 * *
+
+permissions:
+  contents: read
 
 jobs:
   main:
     name: Tag
     runs-on: ubuntu-latest
     steps:
+      - name: Load Secrets
+        id: load-secrets
+        uses: 1password/load-secrets-action@3a12b0ab99d9cd590a3e9b5a90ea017210ed9556 # v4.0.1
+        env:
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+          GITHUB_BOT_APP_CLIENT_ID: op://kubernetes/github-bot/GITHUB_BOT_APP_CLIENT_ID
+          GITHUB_BOT_APP_PRIVATE_KEY: op://kubernetes/github-bot/GITHUB_BOT_APP_PRIVATE_KEY
+
       - name: Generate Token
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token
         with:
-          app-id: "${{ secrets.BOT_APP_ID }}"
-          private-key: "${{ secrets.BOT_APP_PRIVATE_KEY }}"
+          client-id: ${{ steps.load-secrets.outputs.GITHUB_BOT_APP_CLIENT_ID }}
+          private-key: ${{ steps.load-secrets.outputs.GITHUB_BOT_APP_PRIVATE_KEY }}
+          permission-contents: write
 
       - name: Get Previous Tag and Determine Next Tag
         id: determine-next-tag
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
-          github-token: "${{ steps.app-token.outputs.token }}"
+          github-token: ${{ steps.app-token.outputs.token }}
           result-encoding: string
           script: |
             const { data: tags } = await github.rest.repos.listTags({
@@ -44,11 +56,13 @@ jobs:
             return `${nextMajorMinor}.${nextPatch}`;
 
       - name: Create Tag
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          TAG_NAME: ${{ steps.determine-next-tag.outputs.result }}
         with:
-          github-token: "${{ steps.app-token.outputs.token }}"
-          script: |
-            const tagName = "${{ steps.determine-next-tag.outputs.result }}";
+          github-token: ${{ steps.app-token.outputs.token }}
+          script: |-
+            const tagName = process.env.TAG_NAME;
 
             const tag = await github.rest.git.createTag({
               owner: context.repo.owner,

--- a/kubernetes/apps/storage/influxdb/app/helmrelease.yaml
+++ b/kubernetes/apps/storage/influxdb/app/helmrelease.yaml
@@ -39,6 +39,11 @@ spec:
             image:
               repository: influxdb
               tag: 2.9-alpine
+            command: ["influxd"]
+            args:
+              - --bolt-path=/var/lib/influxdb2/influxd.bolt
+              - --engine-path=/var/lib/influxdb2/engine
+              - --sqlite-path=/var/lib/influxdb2/influxd.sqlite
             env:
               DOCKER_INFLUXDB_INIT_MODE: setup
             envFrom:

--- a/kubernetes/apps/storage/influxdb/app/helmrelease.yaml
+++ b/kubernetes/apps/storage/influxdb/app/helmrelease.yaml
@@ -53,6 +53,26 @@ spec:
               allowPrivilegeEscalation: false
               capabilities:
                 drop: ["ALL"]
+            probes:
+              liveness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /health
+                    port: 8086
+                  initialDelaySeconds: 10
+                  periodSeconds: 30
+                  failureThreshold: 3
+              readiness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /health
+                    port: 8086
+                  initialDelaySeconds: 5
+                  periodSeconds: 10
             resources:
               requests:
                 cpu: 10m


### PR DESCRIPTION
## Summary

The influxdb:2.9-alpine entrypoint uses `dasel` to modify a config file during setup. When running as non-root (uid 1000), it cannot write to `/etc/influxdb2` and fails with dasel errors on every restart.

## What happened

- ext4 filesystem on the influxdb PVC went read-only (corruption detected by kernel)
- This caused 1655+ restarts over 37 days
- After deleting and recreating the PVC, the entrypoint couldn't complete initial setup as non-root

## Fix

Bypass the entrypoint entirely by running `influxd` directly with explicit paths:
- `--bolt-path=/var/lib/influxdb2/influxd.bolt`
- `--engine-path=/var/lib/influxdb2/engine`
- `--sqlite-path=/var/lib/influxdb2/influxd.sqlite`

This avoids the chmod/dasel issues while maintaining the security context (non-root, drop ALL caps).

## Tested

- Live-patched deployment is running stable (1/1 Ready, 0 restarts)
- Initial setup completed via `influx setup` CLI (org: home, bucket: health, 7d retention)