### PR TITLE
feat(agentgateway): unified content-based model routing

### DIFF
--- a/kubernetes/apps/network/agentgateway/llm/kustomization.yaml
+++ b/kubernetes/apps/network/agentgateway/llm/kustomization.yaml
@@ -5,6 +5,7 @@ resources:
   - ./externalsecret.yaml
   - ./backends.yaml
   - ./routes.yaml
+  - ./router.yaml
   - ./audio.yaml
   - ./embeddings.yaml
   - ./securitypolicy.yaml

--- a/kubernetes/apps/network/agentgateway/llm/router.yaml
+++ b/kubernetes/apps/network/agentgateway/llm/router.yaml
@@ -1,0 +1,183 @@
+---
+apiVersion: agentgateway.dev/v1alpha1
+kind: AgentgatewayPolicy
+metadata:
+  name: router
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: ai
+  traffic:
+    phase: PreRouting
+    transformation:
+      request:
+        set:
+          - name: "x-model"
+            value: 'coalesce(json(request.body).model, "")'
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: llm
+spec:
+  parentRefs:
+    - name: ai
+      namespace: network
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /v1/chat/completions
+          headers:
+            - type: RegularExpression
+              name: x-model
+              value: "^claude-opus-4-6.*"
+      backendRefs:
+        - name: claude-opus
+          group: agentgateway.dev
+          kind: AgentgatewayBackend
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /v1/chat/completions
+          headers:
+            - type: RegularExpression
+              name: x-model
+              value: "^claude-opus-4-7.*"
+      backendRefs:
+        - name: claude-opus-4-7
+          group: agentgateway.dev
+          kind: AgentgatewayBackend
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /v1/chat/completions
+          headers:
+            - type: RegularExpression
+              name: x-model
+              value: "^claude-opus-4-5.*"
+      backendRefs:
+        - name: claude-opus-4-5
+          group: agentgateway.dev
+          kind: AgentgatewayBackend
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /v1/chat/completions
+          headers:
+            - type: RegularExpression
+              name: x-model
+              value: "^claude-sonnet-4-6.*"
+      backendRefs:
+        - name: claude-sonnet-4-6
+          group: agentgateway.dev
+          kind: AgentgatewayBackend
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /v1/chat/completions
+          headers:
+            - type: RegularExpression
+              name: x-model
+              value: "^claude-sonnet-4-5.*"
+      backendRefs:
+        - name: claude-sonnet-4-5
+          group: agentgateway.dev
+          kind: AgentgatewayBackend
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /v1/chat/completions
+          headers:
+            - type: RegularExpression
+              name: x-model
+              value: "^claude-sonnet-4$"
+      backendRefs:
+        - name: claude-sonnet-4
+          group: agentgateway.dev
+          kind: AgentgatewayBackend
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /v1/chat/completions
+          headers:
+            - type: RegularExpression
+              name: x-model
+              value: "^claude-haiku.*"
+      backendRefs:
+        - name: claude-haiku
+          group: agentgateway.dev
+          kind: AgentgatewayBackend
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /v1/chat/completions
+          headers:
+            - type: RegularExpression
+              name: x-model
+              value: "^gemma.*"
+      backendRefs:
+        - name: mlx-gemma
+          group: agentgateway.dev
+          kind: AgentgatewayBackend
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /v1/chat/completions
+          headers:
+            - type: RegularExpression
+              name: x-model
+              value: "^deepseek.*"
+      backendRefs:
+        - name: deepseek-3-2
+          group: agentgateway.dev
+          kind: AgentgatewayBackend
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /v1/chat/completions
+          headers:
+            - type: RegularExpression
+              name: x-model
+              value: "^minimax-m2\\.5.*"
+      backendRefs:
+        - name: minimax-m2-5
+          group: agentgateway.dev
+          kind: AgentgatewayBackend
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /v1/chat/completions
+          headers:
+            - type: RegularExpression
+              name: x-model
+              value: "^minimax-m2\\.1.*"
+      backendRefs:
+        - name: minimax-m2-1
+          group: agentgateway.dev
+          kind: AgentgatewayBackend
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /v1/chat/completions
+          headers:
+            - type: RegularExpression
+              name: x-model
+              value: "^glm-5.*"
+      backendRefs:
+        - name: glm-5
+          group: agentgateway.dev
+          kind: AgentgatewayBackend
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /v1/chat/completions
+          headers:
+            - type: RegularExpression
+              name: x-model
+              value: "^qwen3-coder.*"
+      backendRefs:
+        - name: qwen3-coder-next
+          group: agentgateway.dev
+          kind: AgentgatewayBackend


### PR DESCRIPTION
## Summary

Adds a single `/v1/chat/completions` endpoint that routes based on the `model` field in the request body — standard OpenAI SDK pattern.

## Changes

- **AgentgatewayPolicy `extract-model`**: PreRouting phase transformation extracts `model` from JSON body into `x-model` header using CEL expression
- **HTTPRoute `llm`**: Single route with regex header matching to route to correct backend

## How it works

```
Client → POST /v1/chat/completions {"model": "claude-opus-4-6", ...}
       → PreRouting: body.model → x-model header
       → Header match: x-model=claude-opus-4-6 → claude-opus backend
```

## Supported models

All existing backends: claude-opus-4-6, claude-opus-4-7, claude-opus-4-5, claude-sonnet-4-6, claude-sonnet-4-5, claude-sonnet-4, claude-haiku, gemma-4, deepseek, minimax-m2.5, minimax-m2.1, glm-5, qwen3-coder

## Migration

Existing path-based routes (`/v1/opus/...`, `/v1/haiku/...`) preserved for backward compat. Once all consumers migrate to the unified endpoint, old routes can be removed.

## TODO (follow-up)

- [ ] Update nix-darwin configs to use unified endpoint
- [ ] Update OpenClaw gateway config
- [ ] Update other cluster consumers
- [ ] Remove legacy path-based routes once migrated

## Requires

agentgateway PreRouting phase + transformation CEL support (verify v1.1.0 compat)