### PR TITLE
feat(agentgateway): migrate consumers to unified /v1 endpoint

### DIFF
--- a/kubernetes/apps/ai/openclaw/app/externalsecret.yaml
+++ b/kubernetes/apps/ai/openclaw/app/externalsecret.yaml
@@ -75,7 +75,7 @@ spec:
               ],
               "defaults": {
                 "model": {
-                  "primary": "gateway/opus"
+                  "primary": "gateway/claude-opus-4-6"
                 },
                 "timeoutSeconds": 600,
                 "elevatedDefault": "full",
@@ -116,7 +116,7 @@ spec:
                     "enabled": true,
                     "softThresholdTokens": 12000,
                     "prompt": "Extract key decisions, state changes, lessons, blockers to memory/YYYY-MM-DD.md. Format: ## [HH:MM] Topic. Skip routine work. NO_FLUSH if nothing important.",
-                    "model": "haiku/haiku"
+                    "model": "gateway/claude-haiku-4.5"
                   }
                 }
               }
@@ -125,30 +125,20 @@ spec:
               "mode": "merge",
               "providers": {
                 "gateway": {
-                  "baseUrl": "https://gateway.goyangi.io/v1/opus",
+                  "baseUrl": "https://gateway.goyangi.io/v1",
                   "apiKey": "{{ .AGENTGATEWAY_OPENCLAW_API_KEY }}",
                   "api": "openai-completions",
                   "request": { "allowPrivateNetwork": true },
                   "models": [
-                    { "id": "opus", "name": "Opus (Gemma 4 failover)", "contextTokens": 1000000, "reasoning": true }
-                  ]
-                },
-                "local": {
-                  "baseUrl": "http://mac.internal:8080/v1",
-                  "apiKey": "dummy",
-                  "api": "openai-completions",
-                  "request": { "allowPrivateNetwork": true },
-                  "models": [
-                    { "id": "gemma4", "name": "Gemma 4 E4B (direct)" }
-                  ]
-                },
-                "haiku": {
-                  "baseUrl": "https://gateway.goyangi.io/v1/haiku",
-                  "apiKey": "{{ .AGENTGATEWAY_OPENCLAW_API_KEY }}",
-                  "api": "openai-completions",
-                  "request": { "allowPrivateNetwork": true },
-                  "models": [
-                    { "id": "haiku", "name": "Haiku 4.5 (via agentgateway)" }
+                    { "id": "claude-opus-4-6", "name": "Opus 4.6", "contextTokens": 1000000, "reasoning": true },
+                    { "id": "claude-haiku-4.5", "name": "Haiku 4.5", "contextTokens": 200000 },
+                    { "id": "claude-sonnet-4-6", "name": "Sonnet 4.6", "contextTokens": 200000, "reasoning": true },
+                    { "id": "claude-opus-4-7", "name": "Opus 4.7", "contextTokens": 1000000, "reasoning": true },
+                    { "id": "deepseek", "name": "DeepSeek 3.2", "contextTokens": 128000, "reasoning": true },
+                    { "id": "gemma-4", "name": "Gemma 4 E4B (local)", "contextTokens": 128000, "reasoning": true },
+                    { "id": "glm-5", "name": "GLM-5", "contextTokens": 128000 },
+                    { "id": "minimax-m2.5", "name": "MiniMax M2.5", "contextTokens": 1000000 },
+                    { "id": "qwen3-coder", "name": "Qwen3 Coder", "contextTokens": 256000, "reasoning": true }
                   ]
                 }
               }

--- a/kubernetes/apps/default/mealie/app/externalsecret.yaml
+++ b/kubernetes/apps/default/mealie/app/externalsecret.yaml
@@ -29,9 +29,9 @@ spec:
         OIDC_ADMIN_GROUP: admin
         OIDC_AUTO_REDIRECT: "True"
         OIDC_REMEMBER_ME: "True"
-        OPENAI_BASE_URL: https://gateway.goyangi.io/v1/gpt-oss-120b
+        OPENAI_BASE_URL: https://gateway.goyangi.io/v1
         OPENAI_API_KEY: "{{ .AGENTGATEWAY_API_KEY }}"
-        OPENAI_MODEL: gpt-oss-120b
+        OPENAI_MODEL: claude-haiku-4.5
   dataFrom:
     - extract:
         key: mealie

--- a/kubernetes/apps/network/agentgateway/llm/kustomization.yaml
+++ b/kubernetes/apps/network/agentgateway/llm/kustomization.yaml
@@ -5,6 +5,7 @@ resources:
   - ./externalsecret.yaml
   - ./backends.yaml
   - ./routes.yaml
+  - ./router.yaml
   - ./audio.yaml
   - ./embeddings.yaml
   - ./securitypolicy.yaml

--- a/kubernetes/apps/network/agentgateway/llm/router.yaml
+++ b/kubernetes/apps/network/agentgateway/llm/router.yaml
@@ -1,0 +1,183 @@
+---
+apiVersion: agentgateway.dev/v1alpha1
+kind: AgentgatewayPolicy
+metadata:
+  name: router
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: ai
+  traffic:
+    phase: PreRouting
+    transformation:
+      request:
+        set:
+          - name: "x-model"
+            value: 'coalesce(json(request.body).model, "")'
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: llm
+spec:
+  parentRefs:
+    - name: ai
+      namespace: network
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /v1/chat/completions
+          headers:
+            - type: RegularExpression
+              name: x-model
+              value: "^claude-opus-4-6.*"
+      backendRefs:
+        - name: claude-opus
+          group: agentgateway.dev
+          kind: AgentgatewayBackend
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /v1/chat/completions
+          headers:
+            - type: RegularExpression
+              name: x-model
+              value: "^claude-opus-4-7.*"
+      backendRefs:
+        - name: claude-opus-4-7
+          group: agentgateway.dev
+          kind: AgentgatewayBackend
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /v1/chat/completions
+          headers:
+            - type: RegularExpression
+              name: x-model
+              value: "^claude-opus-4-5.*"
+      backendRefs:
+        - name: claude-opus-4-5
+          group: agentgateway.dev
+          kind: AgentgatewayBackend
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /v1/chat/completions
+          headers:
+            - type: RegularExpression
+              name: x-model
+              value: "^claude-sonnet-4-6.*"
+      backendRefs:
+        - name: claude-sonnet-4-6
+          group: agentgateway.dev
+          kind: AgentgatewayBackend
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /v1/chat/completions
+          headers:
+            - type: RegularExpression
+              name: x-model
+              value: "^claude-sonnet-4-5.*"
+      backendRefs:
+        - name: claude-sonnet-4-5
+          group: agentgateway.dev
+          kind: AgentgatewayBackend
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /v1/chat/completions
+          headers:
+            - type: RegularExpression
+              name: x-model
+              value: "^claude-sonnet-4$"
+      backendRefs:
+        - name: claude-sonnet-4
+          group: agentgateway.dev
+          kind: AgentgatewayBackend
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /v1/chat/completions
+          headers:
+            - type: RegularExpression
+              name: x-model
+              value: "^claude-haiku.*"
+      backendRefs:
+        - name: claude-haiku
+          group: agentgateway.dev
+          kind: AgentgatewayBackend
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /v1/chat/completions
+          headers:
+            - type: RegularExpression
+              name: x-model
+              value: "^gemma.*"
+      backendRefs:
+        - name: mlx-gemma
+          group: agentgateway.dev
+          kind: AgentgatewayBackend
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /v1/chat/completions
+          headers:
+            - type: RegularExpression
+              name: x-model
+              value: "^deepseek.*"
+      backendRefs:
+        - name: deepseek-3-2
+          group: agentgateway.dev
+          kind: AgentgatewayBackend
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /v1/chat/completions
+          headers:
+            - type: RegularExpression
+              name: x-model
+              value: "^minimax-m2\\.5.*"
+      backendRefs:
+        - name: minimax-m2-5
+          group: agentgateway.dev
+          kind: AgentgatewayBackend
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /v1/chat/completions
+          headers:
+            - type: RegularExpression
+              name: x-model
+              value: "^minimax-m2\\.1.*"
+      backendRefs:
+        - name: minimax-m2-1
+          group: agentgateway.dev
+          kind: AgentgatewayBackend
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /v1/chat/completions
+          headers:
+            - type: RegularExpression
+              name: x-model
+              value: "^glm-5.*"
+      backendRefs:
+        - name: glm-5
+          group: agentgateway.dev
+          kind: AgentgatewayBackend
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /v1/chat/completions
+          headers:
+            - type: RegularExpression
+              name: x-model
+              value: "^qwen3-coder.*"
+      backendRefs:
+        - name: qwen3-coder-next
+          group: agentgateway.dev
+          kind: AgentgatewayBackend


### PR DESCRIPTION
## Summary

Migrates OpenClaw and Mealie to the unified content-based routing endpoint from #4121.

## Changes

### OpenClaw
- Consolidated 3 providers (gateway, local, haiku) into single `gateway` provider
- Base URL: `https://gateway.goyangi.io/v1` (model field handles routing)
- Model IDs match router regex patterns: `claude-opus-4-6`, `claude-haiku-4.5`, `claude-sonnet-4-6`, etc.
- All 9 models available from one provider
- Updated compaction flush model ref: `haiku/haiku` → `gateway/claude-haiku-4.5`
- Updated primary model: `gateway/opus` → `gateway/claude-opus-4-6`

### Mealie
- Switched from dead `gpt-oss-120b` route to `claude-haiku-4.5`
- Base URL: `https://gateway.goyangi.io/v1`

## Also done (not in this PR)
- OpenCode config on mac.internal updated to unified endpoint (tested, working)

## Tested
- `curl /v1/chat/completions {model: claude-haiku-4.5}` → routed correctly ✅