### PR TITLE
feat(agentgateway): add /v1/models discovery endpoint

### DIFF
--- a/kubernetes/apps/network/agentgateway/ks.yaml
+++ b/kubernetes/apps/network/agentgateway/ks.yaml
@@ -73,3 +73,22 @@ spec:
     name: flux-system
     namespace: flux-system
   wait: false
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: agentgateway-models
+spec:
+  targetNamespace: network
+  dependsOn:
+    - name: agentgateway-gateway
+      namespace: network
+  interval: 1h
+  path: ./kubernetes/apps/network/agentgateway/models
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  wait: false

--- a/kubernetes/apps/network/agentgateway/models/backend.yaml
+++ b/kubernetes/apps/network/agentgateway/models/backend.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: agentgateway.dev/v1alpha1
+kind: AgentgatewayBackend
+metadata:
+  name: agentgateway-models
+spec:
+  ai:
+    groups:
+      - providers:
+          - name: models
+            openai:
+              model: models
+            host: agentgateway-models.network.svc.cluster.local
+            port: 8080

--- a/kubernetes/apps/network/agentgateway/models/configmap.yaml
+++ b/kubernetes/apps/network/agentgateway/models/configmap.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: agentgateway-models
+data:
+  models.json: |
+    {"object": "list", "data": []}

--- a/kubernetes/apps/network/agentgateway/models/cronjob.yaml
+++ b/kubernetes/apps/network/agentgateway/models/cronjob.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: agentgateway-models-sync
+spec:
+  schedule: "*/5 * * * *"
+  concurrencyPolicy: Replace
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      ttlSecondsAfterFinished: 300
+      template:
+        spec:
+          serviceAccountName: agentgateway-models
+          restartPolicy: OnFailure
+          containers:
+            - name: sync
+              image: registry.k8s.io/kubectl:v1.36.0
+              command: ["/bin/sh", "-c"]
+              args:
+                - |
+                  set -e
+                  MODELS=$(kubectl get httproute llm -o json | \
+                    jq -c '[.spec.rules[].matches[].headers[] | select(.name=="x-model") | .value | ltrimstr("^") | rtrimstr(".*") | rtrimstr("$")] | unique | {object:"list", data: [.[] | {id:., object:"model", owned_by:"agentgateway", created: 0}]}')
+                  kubectl create configmap agentgateway-models \
+                    --from-literal=models.json="$MODELS" \
+                    --dry-run=client -o yaml | kubectl apply -f -

--- a/kubernetes/apps/network/agentgateway/models/deployment.yaml
+++ b/kubernetes/apps/network/agentgateway/models/deployment.yaml
@@ -1,0 +1,50 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: agentgateway-models
+  annotations:
+    reloader.stakater.com/auto: "true"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: agentgateway-models
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: agentgateway-models
+    spec:
+      containers:
+        - name: server
+          image: busybox:1.37
+          command: ["httpd", "-f", "-p", "8080", "-h", "/data"]
+          ports:
+            - containerPort: 8080
+              name: http
+          volumeMounts:
+            - name: models
+              mountPath: /data/v1
+              readOnly: true
+          resources:
+            requests:
+              cpu: 5m
+              memory: 8Mi
+            limits:
+              memory: 16Mi
+          livenessProbe:
+            tcpSocket:
+              port: 8080
+            initialDelaySeconds: 2
+          readinessProbe:
+            httpGet:
+              path: /v1/models
+              port: 8080
+            initialDelaySeconds: 2
+      volumes:
+        - name: models
+          configMap:
+            name: agentgateway-models
+            items:
+              - key: models.json
+                path: models

--- a/kubernetes/apps/network/agentgateway/models/httproute.yaml
+++ b/kubernetes/apps/network/agentgateway/models/httproute.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: models
+spec:
+  parentRefs:
+    - name: ai
+      namespace: network
+  rules:
+    - matches:
+        - path:
+            type: Exact
+            value: /v1/models
+      backendRefs:
+        - name: agentgateway-models
+          group: agentgateway.dev
+          kind: AgentgatewayBackend

--- a/kubernetes/apps/network/agentgateway/models/kustomization.yaml
+++ b/kubernetes/apps/network/agentgateway/models/kustomization.yaml
@@ -1,0 +1,12 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./backend.yaml
+  - ./configmap.yaml
+  - ./cronjob.yaml
+  - ./deployment.yaml
+  - ./httproute.yaml
+  - ./rbac.yaml
+  - ./service.yaml

--- a/kubernetes/apps/network/agentgateway/models/rbac.yaml
+++ b/kubernetes/apps/network/agentgateway/models/rbac.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: agentgateway-models
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: agentgateway-models
+rules:
+  - apiGroups: ["gateway.networking.k8s.io"]
+    resources: ["httproutes"]
+    verbs: ["get", "list"]
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get", "create", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: agentgateway-models
+subjects:
+  - kind: ServiceAccount
+    name: agentgateway-models
+roleRef:
+  kind: Role
+  name: agentgateway-models
+  apiGroup: rbac.authorization.k8s.io

--- a/kubernetes/apps/network/agentgateway/models/service.yaml
+++ b/kubernetes/apps/network/agentgateway/models/service.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: agentgateway-models
+spec:
+  selector:
+    app.kubernetes.io/name: agentgateway-models
+  ports:
+    - port: 8080
+      targetPort: http
+      name: http


### PR DESCRIPTION
## Summary
Adds a static `/v1/models` endpoint to agentgateway for OpenAI-compatible model discovery.

## How it works
- CronJob runs every 5min, reads model names from HTTPRoute `llm` header matches
- Patches a ConfigMap with the models JSON
- busybox httpd serves the static response at `/v1/models`
- Stakater Reloader auto-restarts the server pod on ConfigMap changes
- AgentgatewayBackend CRD + HTTPRoute for routing through the `ai` Gateway

## Enables
- `CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY=1` auto-discovers available models
- Any OpenAI-compatible client can hit `gateway.goyangi.io/v1/models`

## Fallback
If AgentgatewayBackend passthrough doesn't work (v1.1.0 limitation), fallback is option B: sidecar on the agentgateway pod itself.