### PR TITLE
add mac.internal node-exporter scrape target

### DIFF
--- a/kubernetes/apps/o11y/kube-prometheus-stack/app/scrapeconfig.yaml
+++ b/kubernetes/apps/o11y/kube-prometheus-stack/app/scrapeconfig.yaml
@@ -8,6 +8,7 @@ spec:
   staticConfigs:
     - targets:
         - nas.internal:9100
+        - mac.internal:9100
   metricsPath: /metrics
   relabelings:
     - action: replace


### PR DESCRIPTION
Adds mac.internal:9100 to the existing node-exporter ScrapeConfig. Node exporter is already running via nix-darwin launchagent.