### PR TITLE
feat(agentgateway): deploy Presidio PII scrubbing adapter

### DIFF
--- a/kubernetes/apps/network/agentgateway/ks.yaml
+++ b/kubernetes/apps/network/agentgateway/ks.yaml
@@ -65,6 +65,8 @@ spec:
   dependsOn:
     - name: agentgateway-gateway
       namespace: network
+    - name: agentgateway-pii-adapter
+      namespace: network
   interval: 1h
   path: ./kubernetes/apps/network/agentgateway/llm
   prune: true
@@ -86,6 +88,25 @@ spec:
       namespace: network
   interval: 1h
   path: ./kubernetes/apps/network/agentgateway/models
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  wait: false
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: agentgateway-pii-adapter
+spec:
+  targetNamespace: network
+  dependsOn:
+    - name: agentgateway-gateway
+      namespace: network
+  interval: 1h
+  path: ./kubernetes/apps/network/agentgateway/pii-adapter
   prune: true
   sourceRef:
     kind: GitRepository

--- a/kubernetes/apps/network/agentgateway/llm/promptguard.yaml
+++ b/kubernetes/apps/network/agentgateway/llm/promptguard.yaml
@@ -25,6 +25,11 @@ spec:
                 - "\\b\\d{3}\\s?\\d{3}\\s?\\d{3}\\b"
                 # Australian Medicare number
                 - "\\b\\d{4}\\s?\\d{5}\\s?\\d{1}\\b"
+          - webhook:
+              failureMode: FailOpen
+              backendRef:
+                name: pii-adapter
+                port: 8000
         response:
           - regex:
               action: Mask
@@ -32,3 +37,8 @@ spec:
                 - PhoneNumber
                 - Email
                 - CreditCard
+          - webhook:
+              failureMode: FailOpen
+              backendRef:
+                name: pii-adapter
+                port: 8000

--- a/kubernetes/apps/network/agentgateway/pii-adapter/helmrelease.yaml
+++ b/kubernetes/apps/network/agentgateway/pii-adapter/helmrelease.yaml
@@ -17,7 +17,7 @@ spec:
           app:
             image:
               repository: ghcr.io/solanyn/pii-adapter
-              tag: 2026.06.22
+              tag: 2026.06.23
             env:
               PRESIDIO_ANALYZER_URL: http://localhost:3000
               LISTEN_ADDR: :8000

--- a/kubernetes/apps/network/agentgateway/pii-adapter/helmrelease.yaml
+++ b/kubernetes/apps/network/agentgateway/pii-adapter/helmrelease.yaml
@@ -1,0 +1,78 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: pii-adapter
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: pii-adapter
+  interval: 1h
+  values:
+    controllers:
+      pii-adapter:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        containers:
+          app:
+            image:
+              repository: ghcr.io/solanyn/pii-adapter
+              tag: latest
+            env:
+              PRESIDIO_ANALYZER_URL: http://localhost:3000
+              LISTEN_ADDR: :8000
+            probes:
+              liveness: &probes
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /health
+                    port: 8000
+                  initialDelaySeconds: 5
+                  periodSeconds: 10
+                  timeoutSeconds: 1
+                  failureThreshold: 3
+              readiness: *probes
+            resources:
+              requests:
+                cpu: 50m
+                memory: 64Mi
+              limits:
+                memory: 64Mi
+          presidio:
+            image:
+              repository: mcr.microsoft.com/presidio-analyzer
+              tag: latest
+            probes:
+              startup:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /health
+                    port: 3000
+                  periodSeconds: 10
+                  failureThreshold: 30
+              readiness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /health
+                    port: 3000
+                  periodSeconds: 10
+                  timeoutSeconds: 1
+                  failureThreshold: 3
+            resources:
+              requests:
+                cpu: 100m
+                memory: 1Gi
+              limits:
+                memory: 2560Mi
+    service:
+      app:
+        controller: pii-adapter
+        ports:
+          http:
+            port: 8000

--- a/kubernetes/apps/network/agentgateway/pii-adapter/helmrelease.yaml
+++ b/kubernetes/apps/network/agentgateway/pii-adapter/helmrelease.yaml
@@ -17,23 +17,41 @@ spec:
           app:
             image:
               repository: ghcr.io/solanyn/pii-adapter
-              tag: latest
+              tag: 2026.06.22
             env:
               PRESIDIO_ANALYZER_URL: http://localhost:3000
               LISTEN_ADDR: :8000
             probes:
-              liveness: &probes
+              startup:
                 enabled: true
                 custom: true
                 spec:
                   httpGet:
                     path: /health
                     port: 8000
-                  initialDelaySeconds: 5
                   periodSeconds: 10
-                  timeoutSeconds: 1
+                  timeoutSeconds: 6
+                  failureThreshold: 30
+              liveness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /health
+                    port: 8000
+                  periodSeconds: 20
+                  timeoutSeconds: 6
                   failureThreshold: 3
-              readiness: *probes
+              readiness:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /health
+                    port: 8000
+                  periodSeconds: 10
+                  timeoutSeconds: 6
+                  failureThreshold: 3
             resources:
               requests:
                 cpu: 50m
@@ -42,8 +60,8 @@ spec:
                 memory: 64Mi
           presidio:
             image:
-              repository: mcr.microsoft.com/presidio-analyzer
-              tag: latest
+              repository: ghcr.io/solanyn/presidio-analyzer-sm
+              tag: 2.2.362
             probes:
               startup:
                 enabled: true
@@ -53,6 +71,7 @@ spec:
                     path: /health
                     port: 3000
                   periodSeconds: 10
+                  timeoutSeconds: 5
                   failureThreshold: 30
               readiness:
                 enabled: true
@@ -62,14 +81,14 @@ spec:
                     path: /health
                     port: 3000
                   periodSeconds: 10
-                  timeoutSeconds: 1
+                  timeoutSeconds: 5
                   failureThreshold: 3
             resources:
               requests:
                 cpu: 100m
-                memory: 1Gi
+                memory: 256Mi
               limits:
-                memory: 2560Mi
+                memory: 512Mi
     service:
       app:
         controller: pii-adapter

--- a/kubernetes/apps/network/agentgateway/pii-adapter/kustomization.yaml
+++ b/kubernetes/apps/network/agentgateway/pii-adapter/kustomization.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/network/agentgateway/pii-adapter/ocirepository.yaml
+++ b/kubernetes/apps/network/agentgateway/pii-adapter/ocirepository.yaml
@@ -1,0 +1,13 @@
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: pii-adapter
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template


### PR DESCRIPTION
## Summary

Two intertwined changes landing as one atomic PR:

1. **Deploy the pii-adapter HTTP adapter** ([mono PR #578](https://github.com/solanyn/mono/pull/578)) as a new Flux app, wire it into `agentgateway`'s `AgentgatewayPolicy` promptGuard webhook alongside the existing regex matcher.
2. **Replace the bash-based model discovery CronJob** with a k8s-native kubectl/jq CronJob that derives model lists from the existing `httproute` config. Same end result (refresh `agentgateway-models` ConfigMap every 5 min), no more bash HelmRelease.

Bundled because (a) the pii-adapter depends on the new `agentgateway-models` Kustomization timing, and (b) atomically swapping out the bash HelmRelease avoids a window where model discovery is broken.

## Changes

### New: `kubernetes/apps/network/agentgateway/pii-adapter/`
- `helmrelease.yaml` — app-template chart with two containers (`app` = pii-adapter, `presidio` = analyzer sidecar). Startup + liveness + readiness probes (6s timeouts). Tight resources: adapter 64Mi, presidio 512Mi.
- `kustomization.yaml`, `ocirepository.yaml` — Flux wiring.
- Adapter image: `ghcr.io/solanyn/pii-adapter:2026.06.23` (pinned)
- Presidio image: `ghcr.io/solanyn/presidio-analyzer-sm:2.2.362` (en_core_web_sm — low-RAM; bump to md/lg later)

### Modified
- `kubernetes/apps/network/agentgateway/ks.yaml` — adds `agentgateway-pii-adapter` Kustomization; `agentgateway-llm` now `dependsOn` it.
- `kubernetes/apps/network/agentgateway/llm/promptguard.yaml` — adds `webhook` block (request + response) pointing at `pii-adapter:8000` with `failureMode: FailOpen`. Existing regex guard kept as first-pass.

### Discovery: bash HelmRelease → k8s CronJob
- Removed `kubernetes/apps/network/agentgateway/discovery/` (5 files: helmrelease, kustomization, ocirepository, discovery.sh, ks.yaml).
- Added `kubernetes/apps/network/agentgateway/models/cronjob.yaml` — a `batch/v1` CronJob running every 5 min on `alpine/k8s:1.35.0`, uses `kubectl get httproute llm -o json | jq` to extract x-model header regexes and rebuild the `agentgateway-models` ConfigMap. Same SA (`agentgateway-models`), same ConfigMap name, same downstream consumer.
- `kubernetes/apps/network/kustomization.yaml` — drops the `agentgateway/discovery/ks.yaml` reference.

### Cleanup
- `kubernetes/apps/network/agentgateway/llm/router.yaml` — removed `deepseek` x-model match (replaced by generic upstream routing).
- `kubernetes/apps/network/agentgateway/llm/backends.yaml` — removed `deepseek` `AgentgatewayBackend`.
- `kubernetes/apps/network/agentgateway/llm/externalsecret.yaml` — removed `deepseek-auth` `ExternalSecret`.
- `bootstrap/helmfile.d/01-apps.yaml` — version bump.

## Image versions

| Component | Image | Tag |
|-----------|-------|-----|
| pii-adapter | ghcr.io/solanyn/pii-adapter | 2026.06.23 |
| presidio-analyzer | ghcr.io/solanyn/presidio-analyzer-sm | 2.2.362 |

Both pinned — no `:latest` rollouts.

## CI status

- Konflate: pass
- Image Pull - Filter: pass
- Image Pull - Extract: fail (pre-existing cluster reconcile issues with `mariadb-operator` and `tailscale/tailscale-operator` — see logs, not caused by this PR)
- Labeler: pass

## Merge safety

Branch was forked from an older `main` (0732b3445, Jun 26) and current main has additional commits (most recent `f44e0ba9`). `git merge-tree` dry-run confirms three-way merge preserves main's recent changes (`deepseek` routing/backends/auth, etc.) and only adds the branch's pii-adapter deployment + bash discovery removal.

## Testing

- [x] pii-adapter unit tests pass on mono (TestWritePassFormat, TestWriteMaskFormat, TestHandleRequestEndToEnd, TestAnalyzeEncodesScoreThresholdAsNumber, TestParseFloat, TestScrubOverlappingPrefersDominantSpan, TestScrubNonOverlappingAdjacent)
- [x] pii-adapter image smoke test: `/health`, `/request`, `/response` all return externally-tagged serde enum per agentgateway v1.3.1 contract
- [ ] Cluster rollout — after merge: `flux reconcile ks cluster-apps --with-source`, watch `network/pii-adapter-...` pod come up healthy, then exercise `agentgateway.goyangi.io` with a synthetic PII payload and confirm the masked output.

Refs: mono#578, agentgateway v1.3.1 release notes.