### PR TITLE
chore(talos): bump to v1.13.5, kubernetes v1.36.2

### DIFF
--- a/talos/machineconfig.yaml.j2
+++ b/talos/machineconfig.yaml.j2
@@ -50,7 +50,7 @@ machine:
   install:
     diskSelector:
       model: SAMSUNG MZ7LM960
-    image: factory.talos.dev/metal-installer/3b73f15bf9015a0e3884482abb336c43c9a4c4ed021af3410c61852af461f3e7:v1.13.0
+    image: factory.talos.dev/metal-installer/3b73f15bf9015a0e3884482abb336c43c9a4c4ed021af3410c61852af461f3e7:v1.13.5
     wipe: false
   kernel:
     modules:
@@ -63,7 +63,7 @@ machine:
       serializeImagePulls: false
       allowedUnsafeSysctls:
         - net.ipv6.conf.*
-    image: ghcr.io/siderolabs/kubelet:v1.36.1
+    image: ghcr.io/siderolabs/kubelet:v1.36.2
     nodeIP:
       validSubnets:
         - 192.168.42.0/24
@@ -143,13 +143,13 @@ cluster:
       enable-aggregator-routing: "true"
       feature-gates: MutatingAdmissionPolicy=true,HPAScaleToZero=true
       runtime-config: admissionregistration.k8s.io/v1beta1=true
-    image: registry.k8s.io/kube-apiserver:v1.36.1
+    image: registry.k8s.io/kube-apiserver:v1.36.2
   controllerManager:
     extraArgs:
       bind-address: 0.0.0.0
       feature-gates: HPAScaleToZero=true
       node-cidr-mask-size-ipv6: "112"
-    image: registry.k8s.io/kube-controller-manager:v1.36.1
+    image: registry.k8s.io/kube-controller-manager:v1.36.2
   coreDNS:
     disabled: true
   etcd:
@@ -162,7 +162,7 @@ cluster:
       listen-metrics-urls: http://0.0.0.0:2381
   proxy:
     disabled: true
-    image: registry.k8s.io/kube-proxy:v1.36.1
+    image: registry.k8s.io/kube-proxy:v1.36.2
   scheduler:
     config:
       apiVersion: kubescheduler.config.k8s.io/v1
@@ -183,7 +183,7 @@ cluster:
                     whenUnsatisfiable: ScheduleAnyway
     extraArgs:
       bind-address: 0.0.0.0
-    image: registry.k8s.io/kube-scheduler:v1.36.1
+    image: registry.k8s.io/kube-scheduler:v1.36.2
   secretboxEncryptionSecret: op://kubernetes/talos/CLUSTER_SECRETBOXENCRYPTIONSECRET
   serviceAccount:
     key: op://kubernetes/talos/CLUSTER_SERVICEACCOUNT_KEY


### PR DESCRIPTION
## Changes

- Talos installer: `v1.13.0` → `v1.13.5`
- Kubernetes components: `v1.36.1` → `v1.36.2` (kubelet, kube-apiserver, kube-controller-manager, kube-proxy, kube-scheduler)

## Before merging

The Talos schematic ID must be regenerated at https://factory.talos.dev for `v1.13.5` with the current extensions defined in `talos/schematic.yaml.j2`:

- siderolabs/i915
- siderolabs/intel-ucode
- siderolabs/mei
- siderolabs/nfsrahead
- siderolabs/tailscale
- siderolabs/util-linux-tools

Update the hash in `talos/machineconfig.yaml.j2` line 53 before applying the upgrade.