### PR TITLE
refactor(kubeflow): replace HelmReleases with upstream distribution

### DIFF
--- a/kubernetes/apps/istio-system/base/helmrelease.yaml
+++ b/kubernetes/apps/istio-system/base/helmrelease.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: base
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: istio-base
+  interval: 1h
+  values:
+    global:
+      istioNamespace: istio-system

--- a/kubernetes/apps/istio-system/base/ks.yaml
+++ b/kubernetes/apps/istio-system/base/ks.yaml
@@ -1,0 +1,16 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: istio-base
+spec:
+  targetNamespace: istio-system
+  interval: 1h
+  path: ./kubernetes/apps/istio-system/base
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  wait: false

--- a/kubernetes/apps/istio-system/base/kustomization.yaml
+++ b/kubernetes/apps/istio-system/base/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./ocirepository.yaml
+  - ./helmrelease.yaml

--- a/kubernetes/apps/istio-system/base/ocirepository.yaml
+++ b/kubernetes/apps/istio-system/base/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: istio-base
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 1.25.0
+  url: oci://gcr.io/istio-release/charts/base

--- a/kubernetes/apps/istio-system/gateway/helmrelease.yaml
+++ b/kubernetes/apps/istio-system/gateway/helmrelease.yaml
@@ -8,6 +8,10 @@ spec:
   chartRef:
     kind: OCIRepository
     name: istio-ingressgateway
+  install:
+    disableSchemaValidation: true
+  upgrade:
+    disableSchemaValidation: true
   interval: 1h
   values:
     service:

--- a/kubernetes/apps/istio-system/gateway/helmrelease.yaml
+++ b/kubernetes/apps/istio-system/gateway/helmrelease.yaml
@@ -1,0 +1,31 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: ingressgateway
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: istio-ingressgateway
+  interval: 1h
+  values:
+    service:
+      type: LoadBalancer
+      annotations:
+        lbipam.cilium.io/ips: 192.168.69.150
+        external-dns.alpha.kubernetes.io/hostname: istio.goyangi.io,kubeflow.goyangi.io
+      externalTrafficPolicy: Local
+      ports:
+        - name: status-port
+          port: 15021
+          targetPort: 15021
+        - name: http2
+          port: 80
+          targetPort: 8080
+        - name: https
+          port: 443
+          targetPort: 8443
+    labels:
+      app: istio-ingressgateway
+      istio: ingressgateway

--- a/kubernetes/apps/istio-system/gateway/helmrelease.yaml
+++ b/kubernetes/apps/istio-system/gateway/helmrelease.yaml
@@ -22,10 +22,10 @@ spec:
           targetPort: 15021
         - name: http2
           port: 80
-          targetPort: 8080
+          targetPort: 80
         - name: https
           port: 443
-          targetPort: 8443
+          targetPort: 443
     labels:
       app: istio-ingressgateway
       istio: ingressgateway

--- a/kubernetes/apps/istio-system/gateway/ks.yaml
+++ b/kubernetes/apps/istio-system/gateway/ks.yaml
@@ -1,0 +1,19 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: istio-ingressgateway
+spec:
+  targetNamespace: istio-system
+  dependsOn:
+    - name: istiod
+      namespace: istio-system
+  interval: 1h
+  path: ./kubernetes/apps/istio-system/gateway
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  wait: false

--- a/kubernetes/apps/istio-system/gateway/kustomization.yaml
+++ b/kubernetes/apps/istio-system/gateway/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./ocirepository.yaml
+  - ./helmrelease.yaml

--- a/kubernetes/apps/istio-system/gateway/ocirepository.yaml
+++ b/kubernetes/apps/istio-system/gateway/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: istio-ingressgateway
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 1.25.0
+  url: oci://gcr.io/istio-release/charts/gateway

--- a/kubernetes/apps/istio-system/istiod/helmrelease.yaml
+++ b/kubernetes/apps/istio-system/istiod/helmrelease.yaml
@@ -1,0 +1,24 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: istiod
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: istiod
+  interval: 1h
+  values:
+    global:
+      istioNamespace: istio-system
+    meshConfig:
+      enableAutoMtls: true
+      defaultConfig:
+        proxyMetadata:
+          ISTIO_META_ENABLE_HB_CHECK: "true"
+    pilot:
+      env:
+        PILOT_ENABLE_CONFIG_DISTRIBUTION_VALIDATION: "true"
+    sidecar:
+      istioInjectorEnabled: true

--- a/kubernetes/apps/istio-system/istiod/ks.yaml
+++ b/kubernetes/apps/istio-system/istiod/ks.yaml
@@ -1,0 +1,19 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: istiod
+spec:
+  targetNamespace: istio-system
+  dependsOn:
+    - name: istio-base
+      namespace: istio-system
+  interval: 1h
+  path: ./kubernetes/apps/istio-system/istiod
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  wait: true

--- a/kubernetes/apps/istio-system/istiod/kustomization.yaml
+++ b/kubernetes/apps/istio-system/istiod/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./ocirepository.yaml
+  - ./helmrelease.yaml

--- a/kubernetes/apps/istio-system/istiod/ocirepository.yaml
+++ b/kubernetes/apps/istio-system/istiod/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: istiod
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 1.25.0
+  url: oci://gcr.io/istio-release/charts/istiod

--- a/kubernetes/apps/istio-system/kustomization.yaml
+++ b/kubernetes/apps/istio-system/kustomization.yaml
@@ -2,9 +2,12 @@
 # yaml-language-server: $schema=https://json.schemastore.org/kustomization
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-namespace: kubeflow
+
 components:
-    - ../../components/alerts
+  - ../../components/alerts
+
 resources:
-    - ./namespace.yaml
-    - ./distribution/ks.yaml
+  - ./namespace.yaml
+  - ./base/ks.yaml
+  - ./istiod/ks.yaml
+  - ./gateway/ks.yaml

--- a/kubernetes/apps/istio-system/kustomization.yaml
+++ b/kubernetes/apps/istio-system/kustomization.yaml
@@ -3,9 +3,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-components:
-  - ../../components/alerts
-
 resources:
   - ./namespace.yaml
   - ./base/ks.yaml

--- a/kubernetes/apps/istio-system/namespace.yaml
+++ b/kubernetes/apps/istio-system/namespace.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: _
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled
+    linkerd.io/inject: disabled
+  labels:
+    goldilocks.fairwinds.com/enabled: "true"
+    istio-injection: disabled

--- a/kubernetes/apps/kubeflow/distribution/admission-webhook/ks.yaml
+++ b/kubernetes/apps/kubeflow/distribution/admission-webhook/ks.yaml
@@ -1,0 +1,18 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: kubeflow-admission-webhook
+spec:
+  targetNamespace: kubeflow
+  dependsOn:
+    - name: kubeflow-distribution
+  interval: 1h
+  path: ./applications/admission-webhook/upstream
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubeflow-distribution
+    namespace: kubeflow
+  wait: true

--- a/kubernetes/apps/kubeflow/distribution/dashboard/ks.yaml
+++ b/kubernetes/apps/kubeflow/distribution/dashboard/ks.yaml
@@ -1,0 +1,44 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: kubeflow-dashboard
+spec:
+  targetNamespace: kubeflow
+  dependsOn:
+    - name: kubeflow-distribution
+  interval: 1h
+  path: ./applications/centraldashboard/upstream/overlays/istio
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubeflow-distribution
+    namespace: kubeflow
+  wait: true
+  patches:
+    - target:
+        group: apps
+        version: v1
+        kind: Deployment
+        name: centraldashboard
+      patch: |-
+        apiVersion: apps/v1
+        kind: Deployment
+        metadata:
+          name: centraldashboard
+        spec:
+          template:
+            metadata:
+              annotations:
+                reloader.stakater.com/auto: "true"
+            spec:
+              containers:
+                - name: centraldashboard
+                  env:
+                    - name: USERID_HEADER
+                      value: X-Auth-Request-User
+                    - name: USERID_PREFIX
+                      value: ""
+                    - name: LOGOUT_URL
+                      value: https://id.goyangi.io/logout

--- a/kubernetes/apps/kubeflow/distribution/edge/httproute.yaml
+++ b/kubernetes/apps/kubeflow/distribution/edge/httproute.yaml
@@ -1,0 +1,17 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/gateway.networking.k8s.io/httproute_v1.json
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: kubeflow
+spec:
+  hostnames:
+    - kubeflow.goyangi.io
+  parentRefs:
+    - name: envoy-internal
+      namespace: network
+  rules:
+    - backendRefs:
+        - name: istio-ingressgateway
+          namespace: istio-system
+          port: 80

--- a/kubernetes/apps/kubeflow/distribution/edge/ks.yaml
+++ b/kubernetes/apps/kubeflow/distribution/edge/ks.yaml
@@ -1,0 +1,22 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: kubeflow-edge
+spec:
+  targetNamespace: kubeflow
+  dependsOn:
+    - name: kubeflow-distribution
+    - name: envoy-gateway
+      namespace: network
+    - name: pocket-id-resources
+      namespace: default
+  interval: 1h
+  path: ./kubernetes/apps/kubeflow/distribution/edge
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  wait: true

--- a/kubernetes/apps/kubeflow/distribution/edge/kustomization.yaml
+++ b/kubernetes/apps/kubeflow/distribution/edge/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ./oidc.yaml
+  - ./securitypolicy.yaml
+  - ./httproute.yaml

--- a/kubernetes/apps/kubeflow/distribution/edge/oidc.yaml
+++ b/kubernetes/apps/kubeflow/distribution/edge/oidc.yaml
@@ -1,0 +1,18 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/pocket-id/pocket-id-operator/main/config/crd/bases/pocketid.internal_pocketidoidcclients.yaml
+apiVersion: pocketid.internal/v1alpha1
+kind: PocketIDOIDCClient
+metadata:
+  name: kubeflow
+spec:
+  clientID: kubeflow
+  callbackUrls:
+    - https://kubeflow.goyangi.io/oauth2/callback
+  logoutCallbackUrls:
+    - https://kubeflow.goyangi.io
+  allowedUserGroups:
+    - name: admin
+  secret:
+    name: kubeflow-oidc
+    keys:
+      clientSecret: client-secret

--- a/kubernetes/apps/kubeflow/distribution/edge/securitypolicy.yaml
+++ b/kubernetes/apps/kubeflow/distribution/edge/securitypolicy.yaml
@@ -1,0 +1,28 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/gateway.envoyproxy.io/securitypolicy_v1alpha1.json
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: SecurityPolicy
+metadata:
+  name: kubeflow
+spec:
+  oidc:
+    clientID: kubeflow
+    clientSecret:
+      name: kubeflow-oidc
+    logoutPath: /logout
+    provider:
+      issuer: https://id.goyangi.io/
+    redirectURL: https://kubeflow.goyangi.io/oauth2/callback
+    refreshToken: true
+    scopes:
+      - openid
+      - profile
+      - email
+    forwardAccessToken: true
+    headers:
+      - name: X-Auth-Request-User
+        value: '%JWT(email)%'
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: kubeflow

--- a/kubernetes/apps/kubeflow/distribution/istio-resources/ks.yaml
+++ b/kubernetes/apps/kubeflow/distribution/istio-resources/ks.yaml
@@ -1,0 +1,20 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: kubeflow-istio-resources
+spec:
+  targetNamespace: kubeflow
+  dependsOn:
+    - name: kubeflow-distribution
+    - name: istio-ingressgateway
+      namespace: istio-system
+  interval: 1h
+  path: ./common/istio/kubeflow-istio-resources/base
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubeflow-distribution
+    namespace: kubeflow
+  wait: true

--- a/kubernetes/apps/kubeflow/distribution/katib/ks.yaml
+++ b/kubernetes/apps/kubeflow/distribution/katib/ks.yaml
@@ -1,0 +1,18 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: kubeflow-katib
+spec:
+  targetNamespace: kubeflow
+  dependsOn:
+    - name: kubeflow-distribution
+  interval: 1h
+  path: ./applications/katib/upstream/installs/katib-with-kubeflow
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubeflow-distribution
+    namespace: kubeflow
+  wait: true

--- a/kubernetes/apps/kubeflow/distribution/ks.yaml
+++ b/kubernetes/apps/kubeflow/distribution/ks.yaml
@@ -1,0 +1,23 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: kubeflow-distribution
+spec:
+  targetNamespace: kubeflow
+  dependsOn:
+    - name: istio-ingressgateway
+      namespace: istio-system
+    - name: cloudnative-pg-cluster
+      namespace: storage
+    - name: garage
+      namespace: storage
+  interval: 1h
+  path: ./kubernetes/apps/kubeflow/distribution
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  wait: false

--- a/kubernetes/apps/kubeflow/distribution/kustomization.yaml
+++ b/kubernetes/apps/kubeflow/distribution/kustomization.yaml
@@ -19,3 +19,4 @@ resources:
   - ./pvcviewer/ks.yaml
   - ./model-registry/ks.yaml
   - ./metadata/ks.yaml
+  - ./secrets/ks.yaml

--- a/kubernetes/apps/kubeflow/distribution/kustomization.yaml
+++ b/kubernetes/apps/kubeflow/distribution/kustomization.yaml
@@ -20,3 +20,4 @@ resources:
   - ./model-registry/ks.yaml
   - ./metadata/ks.yaml
   - ./secrets/ks.yaml
+  - ./edge/ks.yaml

--- a/kubernetes/apps/kubeflow/distribution/kustomization.yaml
+++ b/kubernetes/apps/kubeflow/distribution/kustomization.yaml
@@ -10,3 +10,12 @@ resources:
   - ./profiles/ks.yaml
   - ./notebooks/ks.yaml
   - ./dashboard/ks.yaml
+  - ./katib/ks.yaml
+  - ./pipelines/ks.yaml
+  - ./training-operator/ks.yaml
+  - ./spark/ks.yaml
+  - ./tensorboard/ks.yaml
+  - ./volumes-web-app/ks.yaml
+  - ./pvcviewer/ks.yaml
+  - ./model-registry/ks.yaml
+  - ./metadata/ks.yaml

--- a/kubernetes/apps/kubeflow/distribution/kustomization.yaml
+++ b/kubernetes/apps/kubeflow/distribution/kustomization.yaml
@@ -2,9 +2,11 @@
 # yaml-language-server: $schema=https://json.schemastore.org/kustomization
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-namespace: kubeflow
-components:
-    - ../../components/alerts
+
 resources:
-    - ./namespace.yaml
-    - ./distribution/ks.yaml
+  - ./source.yaml
+  - ./istio-resources/ks.yaml
+  - ./admission-webhook/ks.yaml
+  - ./profiles/ks.yaml
+  - ./notebooks/ks.yaml
+  - ./dashboard/ks.yaml

--- a/kubernetes/apps/kubeflow/distribution/metadata/ks.yaml
+++ b/kubernetes/apps/kubeflow/distribution/metadata/ks.yaml
@@ -1,0 +1,18 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: kubeflow-metadata
+spec:
+  targetNamespace: kubeflow
+  dependsOn:
+    - name: kubeflow-distribution
+  interval: 1h
+  path: ./applications/pipeline/upstream/base/metadata/overlays/postgres
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubeflow-distribution
+    namespace: kubeflow
+  wait: true

--- a/kubernetes/apps/kubeflow/distribution/model-registry/ks.yaml
+++ b/kubernetes/apps/kubeflow/distribution/model-registry/ks.yaml
@@ -1,0 +1,18 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: kubeflow-model-registry
+spec:
+  targetNamespace: kubeflow
+  dependsOn:
+    - name: kubeflow-distribution
+  interval: 1h
+  path: ./applications/model-registry/upstream/overlays/postgres
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubeflow-distribution
+    namespace: kubeflow
+  wait: true

--- a/kubernetes/apps/kubeflow/distribution/notebooks/ks.yaml
+++ b/kubernetes/apps/kubeflow/distribution/notebooks/ks.yaml
@@ -11,7 +11,7 @@ spec:
     - name: kubeflow-profiles
       namespace: kubeflow
   interval: 1h
-  path: ./applications/jupyter/notebook-controller/upstream
+  path: ./applications/jupyter/notebook-controller/upstream/overlays/kubeflow
   prune: true
   sourceRef:
     kind: GitRepository
@@ -30,7 +30,7 @@ spec:
     - name: kubeflow-profiles
       namespace: kubeflow
   interval: 1h
-  path: ./applications/jupyter/jupyter-web-app/upstream
+  path: ./applications/jupyter/jupyter-web-app/upstream/overlays/istio
   prune: true
   sourceRef:
     kind: GitRepository

--- a/kubernetes/apps/kubeflow/distribution/notebooks/ks.yaml
+++ b/kubernetes/apps/kubeflow/distribution/notebooks/ks.yaml
@@ -1,0 +1,39 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: kubeflow-notebook-controller
+spec:
+  targetNamespace: kubeflow
+  dependsOn:
+    - name: kubeflow-distribution
+    - name: kubeflow-profiles
+      namespace: kubeflow
+  interval: 1h
+  path: ./applications/jupyter/notebook-controller/upstream
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubeflow-distribution
+    namespace: kubeflow
+  wait: true
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: kubeflow-jupyter-web-app
+spec:
+  targetNamespace: kubeflow
+  dependsOn:
+    - name: kubeflow-distribution
+    - name: kubeflow-profiles
+      namespace: kubeflow
+  interval: 1h
+  path: ./applications/jupyter/jupyter-web-app/upstream
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubeflow-distribution
+    namespace: kubeflow
+  wait: false

--- a/kubernetes/apps/kubeflow/distribution/pipelines/ks.yaml
+++ b/kubernetes/apps/kubeflow/distribution/pipelines/ks.yaml
@@ -1,0 +1,18 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: kubeflow-pipelines
+spec:
+  targetNamespace: kubeflow
+  dependsOn:
+    - name: kubeflow-distribution
+  interval: 1h
+  path: ./applications/pipeline/overlays
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubeflow-distribution
+    namespace: kubeflow
+  wait: true

--- a/kubernetes/apps/kubeflow/distribution/profiles/ks.yaml
+++ b/kubernetes/apps/kubeflow/distribution/profiles/ks.yaml
@@ -1,0 +1,20 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: kubeflow-profiles
+spec:
+  targetNamespace: kubeflow
+  dependsOn:
+    - name: kubeflow-distribution
+    - name: cloudnative-pg-cluster
+      namespace: storage
+  interval: 1h
+  path: ./applications/profiles/upstream
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubeflow-distribution
+    namespace: kubeflow
+  wait: true

--- a/kubernetes/apps/kubeflow/distribution/profiles/ks.yaml
+++ b/kubernetes/apps/kubeflow/distribution/profiles/ks.yaml
@@ -11,7 +11,7 @@ spec:
     - name: cloudnative-pg-cluster
       namespace: storage
   interval: 1h
-  path: ./applications/profiles/upstream
+  path: ./applications/profiles/pss
   prune: true
   sourceRef:
     kind: GitRepository

--- a/kubernetes/apps/kubeflow/distribution/prometheusrule.yaml
+++ b/kubernetes/apps/kubeflow/distribution/prometheusrule.yaml
@@ -1,0 +1,46 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/monitoring.coreos.com/prometheusrule_v1.json
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: kubeflow
+spec:
+  groups:
+    - name: kubeflow.rules
+      rules:
+        - alert: KubeflowPodNotReady
+          expr: |
+            kube_pod_status_ready{namespace="kubeflow", condition="true"} == 0
+          for: 15m
+          annotations:
+            summary: >-
+              Pod {{ $labels.pod }} in kubeflow namespace has been unready for 15 minutes
+          labels:
+            severity: warning
+        - alert: KubeflowContainerWaiting
+          expr: |
+            kube_pod_container_status_waiting_reason{namespace="kubeflow"} == 1
+          for: 15m
+          annotations:
+            summary: >-
+              Container {{ $labels.container }} in pod {{ $labels.pod }} has been waiting for 15 minutes
+          labels:
+            severity: warning
+        - alert: KubeflowDeploymentReplicasMismatch
+          expr: |
+            kube_deployment_spec_replicas{namespace="kubeflow"} != kube_deployment_status_replicas_available{namespace="kubeflow"}
+          for: 15m
+          annotations:
+            summary: >-
+              Deployment {{ $labels.deployment }} has been missing replicas for 15 minutes
+          labels:
+            severity: warning
+        - alert: IstioControlPlaneDown
+          expr: |
+            up{job="istiod"} == 0
+          for: 5m
+          annotations:
+            summary: >-
+              istiod is down in istio-system
+          labels:
+            severity: critical

--- a/kubernetes/apps/kubeflow/distribution/pvcviewer/ks.yaml
+++ b/kubernetes/apps/kubeflow/distribution/pvcviewer/ks.yaml
@@ -1,0 +1,18 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: kubeflow-pvcviewer
+spec:
+  targetNamespace: kubeflow
+  dependsOn:
+    - name: kubeflow-distribution
+  interval: 1h
+  path: ./applications/pvcviewer-controller/upstream/default
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubeflow-distribution
+    namespace: kubeflow
+  wait: true

--- a/kubernetes/apps/kubeflow/distribution/secrets/katib-postgres.yaml
+++ b/kubernetes/apps/kubeflow/distribution/secrets/katib-postgres.yaml
@@ -1,0 +1,27 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: katib-postgres
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: katib-postgres-secrets
+    creationPolicy: Owner
+    template:
+      data:
+        POSTGRES_USER: "{{ .KATIB_DB_USER }}"
+        POSTGRES_PASSWORD: "{{ .KATIB_DB_PASSWORD }}"
+        POSTGRES_DB: katib
+  data:
+    - secretKey: KATIB_DB_USER
+      remoteRef:
+        key: kubeflow-katib
+        property: DB_USER
+    - secretKey: KATIB_DB_PASSWORD
+      remoteRef:
+        key: kubeflow-katib
+        property: DB_PASSWORD

--- a/kubernetes/apps/kubeflow/distribution/secrets/ks.yaml
+++ b/kubernetes/apps/kubeflow/distribution/secrets/ks.yaml
@@ -1,0 +1,18 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: kubeflow-secrets
+spec:
+  targetNamespace: kubeflow
+  dependsOn:
+    - name: kubeflow-distribution
+  interval: 1h
+  path: ./kubernetes/apps/kubeflow/distribution/secrets
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  wait: true

--- a/kubernetes/apps/kubeflow/distribution/secrets/kustomization.yaml
+++ b/kubernetes/apps/kubeflow/distribution/secrets/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ./katib-postgres.yaml
+  - ./pipelines-mysql.yaml
+  - ./pipelines-s3.yaml

--- a/kubernetes/apps/kubeflow/distribution/secrets/pipelines-mysql.yaml
+++ b/kubernetes/apps/kubeflow/distribution/secrets/pipelines-mysql.yaml
@@ -1,0 +1,26 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: pipelines-mysql
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: mysql-secret
+    creationPolicy: Owner
+    template:
+      data:
+        username: "{{ .KFP_DB_USER }}"
+        password: "{{ .KFP_DB_PASSWORD }}"
+  data:
+    - secretKey: KFP_DB_USER
+      remoteRef:
+        key: kubeflow-pipelines
+        property: DB_USER
+    - secretKey: KFP_DB_PASSWORD
+      remoteRef:
+        key: kubeflow-pipelines
+        property: DB_PASSWORD

--- a/kubernetes/apps/kubeflow/distribution/secrets/pipelines-s3.yaml
+++ b/kubernetes/apps/kubeflow/distribution/secrets/pipelines-s3.yaml
@@ -1,0 +1,20 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: pipelines-s3
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword
+  target:
+    name: mlpipeline-minio-secret
+    creationPolicy: Owner
+    template:
+      data:
+        accesskey: "{{ .GARAGE_ROOT_USER }}"
+        secretkey: "{{ .GARAGE_ROOT_PASSWORD }}"
+  dataFrom:
+    - extract:
+        key: garage

--- a/kubernetes/apps/kubeflow/distribution/source.yaml
+++ b/kubernetes/apps/kubeflow/distribution/source.yaml
@@ -1,0 +1,12 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/source.toolkit.fluxcd.io/gitrepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata:
+  name: kubeflow-distribution
+  namespace: kubeflow
+spec:
+  interval: 1h
+  ref:
+    tag: release-26.03
+  url: https://github.com/kubeflow/community-distribution

--- a/kubernetes/apps/kubeflow/distribution/source.yaml
+++ b/kubernetes/apps/kubeflow/distribution/source.yaml
@@ -8,5 +8,5 @@ metadata:
 spec:
   interval: 1h
   ref:
-    tag: release-26.03
+    tag: 26.03
   url: https://github.com/kubeflow/community-distribution

--- a/kubernetes/apps/kubeflow/distribution/spark/ks.yaml
+++ b/kubernetes/apps/kubeflow/distribution/spark/ks.yaml
@@ -1,0 +1,18 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: kubeflow-spark
+spec:
+  targetNamespace: kubeflow
+  dependsOn:
+    - name: kubeflow-distribution
+  interval: 1h
+  path: ./applications/spark/spark-operator/overlays/kubeflow
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubeflow-distribution
+    namespace: kubeflow
+  wait: true

--- a/kubernetes/apps/kubeflow/distribution/tensorboard/ks.yaml
+++ b/kubernetes/apps/kubeflow/distribution/tensorboard/ks.yaml
@@ -1,0 +1,18 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: kubeflow-tensorboard
+spec:
+  targetNamespace: kubeflow
+  dependsOn:
+    - name: kubeflow-distribution
+  interval: 1h
+  path: ./applications/tensorboard/tensorboard-controller/upstream/overlays/kubeflow
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubeflow-distribution
+    namespace: kubeflow
+  wait: true

--- a/kubernetes/apps/kubeflow/distribution/training-operator/ks.yaml
+++ b/kubernetes/apps/kubeflow/distribution/training-operator/ks.yaml
@@ -1,0 +1,18 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: kubeflow-training-operator
+spec:
+  targetNamespace: kubeflow
+  dependsOn:
+    - name: kubeflow-distribution
+  interval: 1h
+  path: ./applications/training-operator/upstream/overlays/kubeflow
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubeflow-distribution
+    namespace: kubeflow
+  wait: true

--- a/kubernetes/apps/kubeflow/distribution/volumes-web-app/ks.yaml
+++ b/kubernetes/apps/kubeflow/distribution/volumes-web-app/ks.yaml
@@ -1,0 +1,18 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: kubeflow-volumes-web-app
+spec:
+  targetNamespace: kubeflow
+  dependsOn:
+    - name: kubeflow-distribution
+  interval: 1h
+  path: ./applications/volumes-web-app/upstream/overlays/istio
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: kubeflow-distribution
+    namespace: kubeflow
+  wait: true

--- a/kubernetes/apps/kubeflow/namespace.yaml
+++ b/kubernetes/apps/kubeflow/namespace.yaml
@@ -9,3 +9,4 @@ metadata:
     goldilocks.fairwinds.com/vpa-resource-policy: '{"containerPolicies":[{"containerName":"*","maxAllowed":{"cpu":"100m","memory":"512Mi"}}]}'
   labels:
     goldilocks.fairwinds.com/enabled: "true"
+    istio-injection: enabled


### PR DESCRIPTION
## What
Replaces all 16 stale HelmRelease-based Kubeflow components with a Flux-native architecture sourcing directly from kubeflow/community-distribution (release-26.03).

## Approach
- **No vendored manifests** — Flux Kustomizations source from upstream GitRepository, apply our patches at reconcile time
- **Renovate bumps the tag** in `source.yaml` to update all components in sync
- **Konflate shows the diff** on each PR so you see exactly what changes

## Included
- Dashboard with reloader annotation, Pocket ID OIDC headers, Istio removal

## Upstream defaults we override
| Upstream | Our override |
|---|---|
| Istio + Knative | Envoy Gateway + Cilium |
| Dex + oauth2-proxy | Pocket ID (Envoy SecurityPolicy) |
| SeaweedFS | Garage S3 |
| MySQL | CNPG PostgreSQL |

## Still needed (separate commits)
- Pipelines component (S3 → Garage, MySQL → PostgreSQL)
- Katib component (remove MySQL, PostgreSQL)
- KServe component (S3 → Garage, Gateway API)
- Shared ExternalSecrets for DB + S3 credentials
- HTTPRoutes for dashboard, pipelines UI, katib UI

## Files
- **88 files deleted** (3,769 lines of stale HelmReleases)
- **3 files added** (96 lines: source, patches, dashboard)