### PR TITLE
feat(hermes): declarative Brewfile for agent toolset

### DIFF
--- a/kubernetes/apps/ai/hermes/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/hermes/app/helmrelease.yaml
@@ -82,9 +82,10 @@ spec:
 
                     eval "$("$HOMEBREW_PREFIX/bin/brew" shellenv)"
 
-                    brew install kubectl flux bat shellcheck
-                    # 1password-cli is a cask; supported by linuxbrew 4.x+
-                    brew install --cask 1password-cli || echo "[install-tools] WARN: 1password-cli cask install failed"
+                    # Declarative toolset lives in /tmp/Brewfile (mounted from the
+                    # hermes-config ConfigMap). --no-upgrade keeps the init
+                    # deterministic; version bumps land as follow-up commits.
+                    brew bundle install --no-upgrade --file=/tmp/Brewfile
                   '
 
                 chmod -R a+rx "$BREW_PREFIX/bin"
@@ -166,3 +167,5 @@ spec:
             subPath: config.yaml
           - path: /tmp/hermes-entrypoint.sh
             subPath: entrypoint.sh
+          - path: /tmp/Brewfile
+            subPath: Brewfile

--- a/kubernetes/apps/ai/hermes/app/kustomization.yaml
+++ b/kubernetes/apps/ai/hermes/app/kustomization.yaml
@@ -12,5 +12,6 @@ configMapGenerator:
     files:
       - ./resources/config.yaml
       - ./resources/entrypoint.sh
+      - ./resources/Brewfile
     options:
       disableNameSuffixHash: true

--- a/kubernetes/apps/ai/hermes/app/resources/Brewfile
+++ b/kubernetes/apps/ai/hermes/app/resources/Brewfile
@@ -1,0 +1,30 @@
+# Minimal Brewfile for the Hermes AI agent.
+#
+# Install order is determined by Homebrew (formulae first, casks after).
+# Tapped repositories must be declared before their formulae are referenced.
+#
+# Add to this file only when a concrete use case requires the tool.
+# The init container runs `brew bundle install --no-upgrade`, so any change
+# here creates a reviewable diff in git and triggers a one-time reinstall
+# via the next pod roll.
+
+# --- Cluster + agent runtime ---
+tap "fluxcd/tap"
+brew "kubernetes-cli"      # kubectl — k8s API + cluster self-inspection
+brew "fluxcd/tap/flux"     # flux — GitOps CLI (status, reconcile, suspend)
+brew "1password-cli"       # op — secret retrieval from kubernetes vault
+
+# --- Data shaping (every API skill needs these) ---
+brew "jq"                  # JSON in, JSON out — GitHub API, k8s API
+brew "yq"                  # Same but YAML — Flux manifests, app configs
+
+# --- Secrets / config-as-code ---
+brew "sops"                # Encrypted YAML/JSON in Git; unprivileged decrypt
+
+# --- External services ---
+brew "gh"                  # GitHub CLI — weekly-commits digest cron
+brew "opentofu"            # Unifi config-as-code via ubiquiti-community/unifi
+
+# --- Linting (entrypoint.sh warns if missing) ---
+brew "shellcheck"          # Lint shell scripts before committing
+brew "bat"                 # Nicer cat for config dumps, logs, YAML

--- a/kubernetes/apps/ai/hermes/app/resources/entrypoint.sh
+++ b/kubernetes/apps/ai/hermes/app/resources/entrypoint.sh
@@ -16,5 +16,20 @@ fi
 if ! command -v op >/dev/null 2>&1; then
     echo "[hermes-entrypoint] WARN: op not on PATH"
 fi
+if ! command -v gh >/dev/null 2>&1; then
+    echo "[hermes-entrypoint] WARN: gh not on PATH"
+fi
+if ! command -v tofu >/dev/null 2>&1; then
+    echo "[hermes-entrypoint] WARN: tofu not on PATH"
+fi
+if ! command -v jq >/dev/null 2>&1; then
+    echo "[hermes-entrypoint] WARN: jq not on PATH"
+fi
+if ! command -v yq >/dev/null 2>&1; then
+    echo "[hermes-entrypoint] WARN: yq not on PATH"
+fi
+if ! command -v sops >/dev/null 2>&1; then
+    echo "[hermes-entrypoint] WARN: sops not on PATH"
+fi
 
 exec /opt/hermes/bin/hermes "$@"


### PR DESCRIPTION
Replaces the inline `brew install kubectl flux bat shellcheck; brew install --cask 1password-cli` list with `brew bundle install --no-upgrade --file=/tmp/Brewfile`. Tools now tracked declaratively.

## Initial toolset (10 formulae + 1 tap)

| Group | Tools |
|---|---|
| Core runtime | `kubernetes-cli`, `fluxcd/tap/flux`, `1password-cli` |
| Data shaping | `jq`, `yq` |
| Secrets | `sops` |
| External services | `gh`, `opentofu` |
| Lint/UX | `shellcheck`, `bat` |

`gh` + `opentofu` unblock the deferred weekly-commits cron and Unifi config-as-code work. `jq` + `yq` + `sops` round out the data-shaping toolkit every API skill needs.

## Notes

- `--no-upgrade` for determinism; version bumps land as their own reviewable commits
- Entrypoint now warns about the new tools if missing (matches existing pattern)
- Adds the Brewfile to the hermes-config ConfigMap so it's mounted at `/tmp/Brewfile`

## Verification after merge

```bash
kubectl -n ai logs hermes-<new-pod> -c install-tools | tail -20
kubectl -n ai exec hermes-<new-pod> -- brew list
kubectl -n ai exec hermes-<new-pod> -- gh --version
```