### PR TITLE
feat(hermes): add ServiceAccount + read-only RBAC

### DIFF
--- a/kubernetes/apps/ai/hermes/app/clusterrole.yaml
+++ b/kubernetes/apps/ai/hermes/app/clusterrole.yaml
@@ -1,7 +1,8 @@
-# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/rbac.authorization.k8s.io/clusterrole_v1.json
-#
-# Cluster-wide read-only role for the Hermes AI agent.
-# See rbac.md for the rationale behind every exclusion.
+# Cluster-wide read access for the Hermes agent.
+# Deliberately excluded: secrets cluster-wide, pods/exec, pods/portforward,
+# nodes/proxy, cert-manager approve/deny/sign, admissionregistration,
+# and any verb beyond get/list/watch. GitOps via Flux + humans is the
+# apply path; the agent only proposes.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -12,12 +13,10 @@ metadata:
 rules:
   # Cluster primitives.
   - apiGroups: [""]
-    resources:
-      - namespaces
-      - nodes
+    resources: [namespaces, nodes]
     verbs: ["get", "list", "watch"]
 
-  # All workloads cluster-wide, no secrets.
+  # Workloads cluster-wide (no secrets — see exclusions).
   - apiGroups: [""]
     resources:
       - pods
@@ -33,21 +32,13 @@ rules:
       - replicationcontrollers
     verbs: ["get", "list", "watch"]
 
-  # Workloads cluster-wide.
+  # Controllers, batch, networking cluster-wide.
   - apiGroups: ["apps"]
-    resources:
-      - deployments
-      - statefulsets
-      - daemonsets
+    resources: [deployments, statefulsets, daemonsets]
     verbs: ["get", "list", "watch"]
-
   - apiGroups: ["batch"]
-    resources:
-      - jobs
-      - cronjobs
+    resources: [jobs, cronjobs]
     verbs: ["get", "list", "watch"]
-
-  # Networking cluster-wide.
   - apiGroups: ["networking.k8s.io"]
     resources:
       - ingresses
@@ -59,12 +50,12 @@ rules:
       - grpcroutes
     verbs: ["get", "list", "watch"]
 
-  # All CRDs cluster-wide (so the agent can introspect any custom kind).
+  # CRDs (introspect any custom kind).
   - apiGroups: ["apiextensions.k8s.io"]
-    resources: ["customresourcedefinitions"]
+    resources: [customresourcedefinitions]
     verbs: ["get", "list", "watch"]
 
-  # Flux kinds cluster-wide.
+  # All Flux kinds cluster-wide.
   - apiGroups:
       - source.toolkit.fluxcd.io
       - kustomize.toolkit.fluxcd.io
@@ -74,50 +65,21 @@ rules:
     resources: ["*"]
     verbs: ["get", "list", "watch"]
 
-  # External Secrets cluster-wide (ClusterSecretStores).
+  # External Secrets cluster-scoped kinds.
   - apiGroups: ["external-secrets.io"]
-    resources:
-      - clusterExternalSecrets
-      - clusterSecretStores
+    resources: [clusterExternalSecrets, clusterSecretStores]
     verbs: ["get", "list", "watch"]
 
-  # Metrics (if metrics-server is installed — harmless if absent).
+  # Optional integrations (harmless if absent).
   - apiGroups: ["metrics.k8s.io"]
-    resources:
-      - nodes
-      - pods
+    resources: [nodes, pods]
     verbs: ["get", "list"]
-
-  # Policy (PDBs).
   - apiGroups: ["policy"]
-    resources:
-      - poddisruptionbudgets
+    resources: [poddisruptionbudgets]
     verbs: ["get", "list", "watch"]
-
-  # Storage.
   - apiGroups: ["storage.k8s.io"]
-    resources:
-      - storageclasses
-      - volumeattachments
-      - csidrivers
-      - csinodes
+    resources: [storageclasses, volumeattachments, csidrivers, csinodes]
     verbs: ["get", "list", "watch"]
-
-  # cert-manager (read-only cert state).
   - apiGroups: ["cert-manager.io"]
-    resources:
-      - certificates
-      - certificaterequests
-      - issuers
-      - clusterissuers
-      - orders
-      - challenges
+    resources: [certificates, certificaterequests, issuers, clusterissuers, orders, challenges]
     verbs: ["get", "list", "watch"]
-
-  # NOT included (see rbac.md):
-  #   - secrets cluster-wide (privilege boundary)
-  #   - pods/exec, pods/portforward, pods/eviction (escalation vectors)
-  #   - nodes/proxy (kubelet API = cluster root)
-  #   - any verb beyond get/list/watch
-  #   - cert-manager approve/deny/sign
-  #   - admissionregistration

--- a/kubernetes/apps/ai/hermes/app/clusterrole.yaml
+++ b/kubernetes/apps/ai/hermes/app/clusterrole.yaml
@@ -1,0 +1,123 @@
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/rbac.authorization.k8s.io/clusterrole_v1.json
+#
+# Cluster-wide read-only role for the Hermes AI agent.
+# See rbac.md for the rationale behind every exclusion.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: hermes
+  labels:
+    app.kubernetes.io/name: hermes
+    app.kubernetes.io/part-of: hermes
+rules:
+  # Cluster primitives.
+  - apiGroups: [""]
+    resources:
+      - namespaces
+      - nodes
+    verbs: ["get", "list", "watch"]
+
+  # All workloads cluster-wide, no secrets.
+  - apiGroups: [""]
+    resources:
+      - pods
+      - pods/log
+      - services
+      - configmaps
+      - events
+      - persistentvolumeclaims
+      - serviceaccounts
+      - resourcequotas
+      - limitranges
+      - replicasets
+      - replicationcontrollers
+    verbs: ["get", "list", "watch"]
+
+  # Workloads cluster-wide.
+  - apiGroups: ["apps"]
+    resources:
+      - deployments
+      - statefulsets
+      - daemonsets
+    verbs: ["get", "list", "watch"]
+
+  - apiGroups: ["batch"]
+    resources:
+      - jobs
+      - cronjobs
+    verbs: ["get", "list", "watch"]
+
+  # Networking cluster-wide.
+  - apiGroups: ["networking.k8s.io"]
+    resources:
+      - ingresses
+      - networkpolicies
+      - gateways
+      - gatewayclasses
+      - httproutes
+      - tlsroutes
+      - grpcroutes
+    verbs: ["get", "list", "watch"]
+
+  # All CRDs cluster-wide (so the agent can introspect any custom kind).
+  - apiGroups: ["apiextensions.k8s.io"]
+    resources: ["customresourcedefinitions"]
+    verbs: ["get", "list", "watch"]
+
+  # Flux kinds cluster-wide.
+  - apiGroups:
+      - source.toolkit.fluxcd.io
+      - kustomize.toolkit.fluxcd.io
+      - helm.toolkit.fluxcd.io
+      - notification.toolkit.fluxcd.io
+      - image.toolkit.fluxcd.io
+    resources: ["*"]
+    verbs: ["get", "list", "watch"]
+
+  # External Secrets cluster-wide (ClusterSecretStores).
+  - apiGroups: ["external-secrets.io"]
+    resources:
+      - clusterExternalSecrets
+      - clusterSecretStores
+    verbs: ["get", "list", "watch"]
+
+  # Metrics (if metrics-server is installed — harmless if absent).
+  - apiGroups: ["metrics.k8s.io"]
+    resources:
+      - nodes
+      - pods
+    verbs: ["get", "list"]
+
+  # Policy (PDBs).
+  - apiGroups: ["policy"]
+    resources:
+      - poddisruptionbudgets
+    verbs: ["get", "list", "watch"]
+
+  # Storage.
+  - apiGroups: ["storage.k8s.io"]
+    resources:
+      - storageclasses
+      - volumeattachments
+      - csidrivers
+      - csinodes
+    verbs: ["get", "list", "watch"]
+
+  # cert-manager (read-only cert state).
+  - apiGroups: ["cert-manager.io"]
+    resources:
+      - certificates
+      - certificaterequests
+      - issuers
+      - clusterissuers
+      - orders
+      - challenges
+    verbs: ["get", "list", "watch"]
+
+  # NOT included (see rbac.md):
+  #   - secrets cluster-wide (privilege boundary)
+  #   - pods/exec, pods/portforward, pods/eviction (escalation vectors)
+  #   - nodes/proxy (kubelet API = cluster root)
+  #   - any verb beyond get/list/watch
+  #   - cert-manager approve/deny/sign
+  #   - admissionregistration

--- a/kubernetes/apps/ai/hermes/app/clusterrolebinding.yaml
+++ b/kubernetes/apps/ai/hermes/app/clusterrolebinding.yaml
@@ -1,0 +1,16 @@
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/rbac.authorization.k8s.io/clusterrolebinding_v1.json
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: hermes
+  labels:
+    app.kubernetes.io/name: hermes
+    app.kubernetes.io/part-of: hermes
+subjects:
+  - kind: ServiceAccount
+    name: hermes
+    namespace: ai
+roleRef:
+  kind: ClusterRole
+  name: hermes
+  apiGroup: rbac.authorization.k8s.io

--- a/kubernetes/apps/ai/hermes/app/clusterrolebinding.yaml
+++ b/kubernetes/apps/ai/hermes/app/clusterrolebinding.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/rbac.authorization.k8s.io/clusterrolebinding_v1.json
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:

--- a/kubernetes/apps/ai/hermes/app/helmrelease.yaml
+++ b/kubernetes/apps/ai/hermes/app/helmrelease.yaml
@@ -16,6 +16,7 @@ spec:
         seccompProfile: { type: RuntimeDefault }
     controllers:
       hermes:
+        serviceAccountName: hermes
         annotations:
           reloader.stakater.com/auto: "true"
         initContainers:

--- a/kubernetes/apps/ai/hermes/app/kustomization.yaml
+++ b/kubernetes/apps/ai/hermes/app/kustomization.yaml
@@ -7,6 +7,11 @@ resources:
     - ./httproute.yaml
     - ./ocirepository.yaml
     - ./oidc.yaml
+    - ./serviceaccount.yaml
+    - ./role.yaml
+    - ./rolebinding.yaml
+    - ./clusterrole.yaml
+    - ./clusterrolebinding.yaml
 configMapGenerator:
   - name: hermes-config
     files:

--- a/kubernetes/apps/ai/hermes/app/role.yaml
+++ b/kubernetes/apps/ai/hermes/app/role.yaml
@@ -1,23 +1,5 @@
-# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/rbac.authorization.k8s.io/role_v1.json
-#
-# Least-privilege RBAC for the Hermes AI agent running in the `ai` namespace.
-#
-# Design:
-#   - Role (namespace-scoped): read everything in `ai/` plus log access on
-#     the hermes pod for self-diagnostics. Plus full read on Flux kinds so
-#     the agent can answer "what's the current reconcile state?" without
-#     needing cluster-wide permissions for those.
-#   - ClusterRole: read-only across the cluster for cluster-wide inspection
-#     (nodes, namespaces, CRDs, workloads, Flux sources/HRs/Kustomizations,
-#     external-secrets). NO secrets cluster-wide, NO exec, NO writes.
-#
-# Deliberately excluded:
-#   - pods/exec, pods/portforward: privilege-escalation vector if the agent
-#     mis-execs into another pod. Self-debug uses kubectl logs only.
-#   - secrets cluster-wide: only namespace-scoped secrets are readable.
-#   - create/update/patch/delete on any resource: GitOps via Flux is the
-#     apply path. The agent proposes; humans + Flux apply.
-#   - node proxy: kubelet API = cluster root.
+# Namespace-scoped read access for the Hermes agent.
+# See clusterrole.yaml for cluster-wide reads and exclusion rationale.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -27,7 +9,7 @@ metadata:
     app.kubernetes.io/name: hermes
     app.kubernetes.io/part-of: hermes
 rules:
-  # Core k8s resources in our own namespace (read + watch for live state).
+  # Core k8s resources in `ai/` — incl. secrets here (namespace-scoped only).
   - apiGroups: [""]
     resources:
       - pods
@@ -44,61 +26,28 @@ rules:
       - replicasets
     verbs: ["get", "list", "watch"]
 
-  # Workloads in our own namespace (Helm/Flux-managed deployments).
+  # Workloads + batch + networking within `ai/`.
   - apiGroups: ["apps"]
-    resources:
-      - deployments
-      - statefulsets
-      - daemonsets
+    resources: [deployments, statefulsets, daemonsets]
     verbs: ["get", "list", "watch"]
-
-  # Batch jobs in our own namespace.
   - apiGroups: ["batch"]
-    resources:
-      - jobs
-      - cronjobs
+    resources: [jobs, cronjobs]
     verbs: ["get", "list", "watch"]
-
-  # Networking in our own namespace.
   - apiGroups: ["networking.k8s.io"]
-    resources:
-      - ingresses
-      - networkpolicies
-      - gateways
-      - httproutes
-      - tlsroutes
-      - grpcroutes
+    resources: [ingresses, networkpolicies, gateways, httproutes, tlsroutes, grpcroutes]
     verbs: ["get", "list", "watch"]
 
-  # Flux source controller — GitRepository, OCIRepository, HelmRepository, etc.
-  - apiGroups: ["source.toolkit.fluxcd.io"]
+  # All Flux controllers (read-only) — Kustomizations, HelmReleases, sources, etc.
+  - apiGroups:
+      - source.toolkit.fluxcd.io
+      - kustomize.toolkit.fluxcd.io
+      - helm.toolkit.fluxcd.io
+      - notification.toolkit.fluxcd.io
+      - image.toolkit.fluxcd.io
     resources: ["*"]
     verbs: ["get", "list", "watch"]
 
-  # Flux kustomize-controller — Kustomizations.
-  - apiGroups: ["kustomize.toolkit.fluxcd.io"]
-    resources: ["*"]
-    verbs: ["get", "list", "watch"]
-
-  # Flux helm-controller — HelmReleases (we have one: hermes itself).
-  - apiGroups: ["helm.toolkit.fluxcd.io"]
-    resources: ["*"]
-    verbs: ["get", "list", "watch"]
-
-  # Flux notification-controller — Alerts, Providers, Receivers.
-  - apiGroups: ["notification.toolkit.fluxcd.io"]
-    resources: ["*"]
-    verbs: ["get", "list", "watch"]
-
-  # Flux image-automation-controller.
-  - apiGroups: ["image.toolkit.fluxcd.io"]
-    resources: ["*"]
-    verbs: ["get", "list", "watch"]
-
-  # External Secrets (read-only — so the agent can see what 1Password items
-  # are being projected where, without the ability to create new ones).
+  # External Secrets — namespaced only. ClusterSecretStore is in clusterrole.yaml.
   - apiGroups: ["external-secrets.io"]
-    resources:
-      - externalSecrets
-      - secretStores
+    resources: [externalSecrets, secretStores]
     verbs: ["get", "list", "watch"]

--- a/kubernetes/apps/ai/hermes/app/role.yaml
+++ b/kubernetes/apps/ai/hermes/app/role.yaml
@@ -1,0 +1,104 @@
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/rbac.authorization.k8s.io/role_v1.json
+#
+# Least-privilege RBAC for the Hermes AI agent running in the `ai` namespace.
+#
+# Design:
+#   - Role (namespace-scoped): read everything in `ai/` plus log access on
+#     the hermes pod for self-diagnostics. Plus full read on Flux kinds so
+#     the agent can answer "what's the current reconcile state?" without
+#     needing cluster-wide permissions for those.
+#   - ClusterRole: read-only across the cluster for cluster-wide inspection
+#     (nodes, namespaces, CRDs, workloads, Flux sources/HRs/Kustomizations,
+#     external-secrets). NO secrets cluster-wide, NO exec, NO writes.
+#
+# Deliberately excluded:
+#   - pods/exec, pods/portforward: privilege-escalation vector if the agent
+#     mis-execs into another pod. Self-debug uses kubectl logs only.
+#   - secrets cluster-wide: only namespace-scoped secrets are readable.
+#   - create/update/patch/delete on any resource: GitOps via Flux is the
+#     apply path. The agent proposes; humans + Flux apply.
+#   - node proxy: kubelet API = cluster root.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: hermes
+  namespace: ai
+  labels:
+    app.kubernetes.io/name: hermes
+    app.kubernetes.io/part-of: hermes
+rules:
+  # Core k8s resources in our own namespace (read + watch for live state).
+  - apiGroups: [""]
+    resources:
+      - pods
+      - pods/log
+      - events
+      - configmaps
+      - secrets
+      - services
+      - endpoints
+      - persistentvolumeclaims
+      - serviceaccounts
+      - resourcequotas
+      - limitranges
+      - replicasets
+    verbs: ["get", "list", "watch"]
+
+  # Workloads in our own namespace (Helm/Flux-managed deployments).
+  - apiGroups: ["apps"]
+    resources:
+      - deployments
+      - statefulsets
+      - daemonsets
+    verbs: ["get", "list", "watch"]
+
+  # Batch jobs in our own namespace.
+  - apiGroups: ["batch"]
+    resources:
+      - jobs
+      - cronjobs
+    verbs: ["get", "list", "watch"]
+
+  # Networking in our own namespace.
+  - apiGroups: ["networking.k8s.io"]
+    resources:
+      - ingresses
+      - networkpolicies
+      - gateways
+      - httproutes
+      - tlsroutes
+      - grpcroutes
+    verbs: ["get", "list", "watch"]
+
+  # Flux source controller — GitRepository, OCIRepository, HelmRepository, etc.
+  - apiGroups: ["source.toolkit.fluxcd.io"]
+    resources: ["*"]
+    verbs: ["get", "list", "watch"]
+
+  # Flux kustomize-controller — Kustomizations.
+  - apiGroups: ["kustomize.toolkit.fluxcd.io"]
+    resources: ["*"]
+    verbs: ["get", "list", "watch"]
+
+  # Flux helm-controller — HelmReleases (we have one: hermes itself).
+  - apiGroups: ["helm.toolkit.fluxcd.io"]
+    resources: ["*"]
+    verbs: ["get", "list", "watch"]
+
+  # Flux notification-controller — Alerts, Providers, Receivers.
+  - apiGroups: ["notification.toolkit.fluxcd.io"]
+    resources: ["*"]
+    verbs: ["get", "list", "watch"]
+
+  # Flux image-automation-controller.
+  - apiGroups: ["image.toolkit.fluxcd.io"]
+    resources: ["*"]
+    verbs: ["get", "list", "watch"]
+
+  # External Secrets (read-only — so the agent can see what 1Password items
+  # are being projected where, without the ability to create new ones).
+  - apiGroups: ["external-secrets.io"]
+    resources:
+      - externalSecrets
+      - secretStores
+    verbs: ["get", "list", "watch"]

--- a/kubernetes/apps/ai/hermes/app/rolebinding.yaml
+++ b/kubernetes/apps/ai/hermes/app/rolebinding.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/rbac.authorization.k8s.io/rolebinding_v1.json
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:

--- a/kubernetes/apps/ai/hermes/app/rolebinding.yaml
+++ b/kubernetes/apps/ai/hermes/app/rolebinding.yaml
@@ -1,0 +1,17 @@
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/rbac.authorization.k8s.io/rolebinding_v1.json
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: hermes
+  namespace: ai
+  labels:
+    app.kubernetes.io/name: hermes
+    app.kubernetes.io/part-of: hermes
+subjects:
+  - kind: ServiceAccount
+    name: hermes
+    namespace: ai
+roleRef:
+  kind: Role
+  name: hermes
+  apiGroup: rbac.authorization.k8s.io

--- a/kubernetes/apps/ai/hermes/app/serviceaccount.yaml
+++ b/kubernetes/apps/ai/hermes/app/serviceaccount.yaml
@@ -1,4 +1,3 @@
-# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/core/serviceaccount_v1.json
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -8,7 +7,4 @@ metadata:
   labels:
     app.kubernetes.io/name: hermes
     app.kubernetes.io/part-of: hermes
-  annotations:
-    # Stakater Reloader already watches the `hermes` Secret; no extra annotation needed
-    # here. If we add projected service-account tokens later, this is where they go.
 automountServiceAccountToken: true

--- a/kubernetes/apps/ai/hermes/app/serviceaccount.yaml
+++ b/kubernetes/apps/ai/hermes/app/serviceaccount.yaml
@@ -1,0 +1,14 @@
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/core/serviceaccount_v1.json
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: hermes
+  namespace: ai
+  labels:
+    app.kubernetes.io/name: hermes
+    app.kubernetes.io/part-of: hermes
+  annotations:
+    # Stakater Reloader already watches the `hermes` Secret; no extra annotation needed
+    # here. If we add projected service-account tokens later, this is where they go.
+automountServiceAccountToken: true


### PR DESCRIPTION
The Hermes agent needs authenticated cluster API access for self-inspection and cross-namespace diagnostics. Adds a ServiceAccount + read-only Role (namespace) + ClusterRole (cluster-wide) + bindings.

## What's allowed

All permissions are `get/list/watch` only — **no** `create/update/patch/delete` on any resource.

- **Namespace `ai`**: pods/log, events, configmaps, secrets, services, endpoints, PVCs, serviceaccounts, resourcequotas, limitranges, replicasets, deployments/statefulsets/daemonsets, jobs/cronjobs, ingress/networkpolicy/gateway/httproute/tlsroute/grpcroute, all Flux kinds, ExternalSecret + SecretStore
- **Cluster-wide**: namespaces, nodes, all workloads, all Flux kinds, ClusterExternalSecret + ClusterSecretStore, CRDs, metrics, PDBs, storage classes, cert-manager (read-only cert state)

## What's deliberately excluded

| Exclusion | Why |
|---|---|
| `pods/exec`, `pods/portforward` | Escalation vector if the agent mis-execs into another pod |
| Cluster-wide `secrets` read | Privilege boundary — only namespace-scoped (`ai`) |
| `nodes/proxy` | Kubelet API = cluster root |
| Any `create/update/patch/delete` | GitOps via Flux is the apply path; the agent proposes; humans + Flux apply |
| `cert-manager` approve/deny/sign | CA issuance is sensitive |
| `admissionregistration` | Webhook tampering |

## Changes

- New files: `serviceaccount.yaml`, `role.yaml`, `rolebinding.yaml`, `clusterrole.yaml`, `clusterrolebinding.yaml`
- `kustomization.yaml`: include the 5 new resources
- `helmrelease.yaml`: pin `serviceAccountName: hermes` on the controller

## Verification after merge

```bash
kubectl auth can-i list pods -n ai --as=system:serviceaccount:ai:hermes
# expected: yes

kubectl auth can-i list pods --all-namespaces --as=system:serviceaccount:ai:hermes
# expected: yes (cluster-wide read)

kubectl auth can-i create pods -n ai --as=system:serviceaccount:ai:hermes
# expected: no

kubectl auth can-i exec pods -n ai --as=system:serviceaccount:ai:hermes
# expected: no

kubectl auth can-i get secrets -n kube-system --as=system:serviceaccount:ai:hermes
# expected: no (only ai/ is allowed)
```

## Future elevation (NOT in this PR)

If the agent later needs to:
- Restart a stuck pod → add `pods/delete` + `pods/eviction` to the Role
- Reconcile a Flux Kustomization → add Flux `reconcile` verb via annotation
- Decrypt a SOPS-encrypted secret → add a TokenRequest or sops-key secret

Each goes in its own PR with its own audit trail.