### PR TITLE
feat(hermes): raise memory char limits (40k/12k)

### DIFF
--- a/kubernetes/apps/ai/hermes/app/resources/config.yaml
+++ b/kubernetes/apps/ai/hermes/app/resources/config.yaml
@@ -40,8 +40,8 @@ memory:
   honcho_url: http://honcho.ai.svc.cluster.local
   memory_enabled: true
   user_profile_enabled: true
-  memory_char_limit: 2200
-  user_char_limit: 1375
+  memory_char_limit: 40000
+  user_char_limit: 12000
   nudge_interval: 10
   flush_min_turns: 6
 session_reset:


### PR DESCRIPTION
Bumps `memory_char_limit` from 2200 → 40000 and `user_char_limit` from 1375 → 12000.

For a personal assistant, memory is the core value prop — most turns don't saturate the context window, so dedicating ~10% to recall (40k chars ≈ 10k tokens) is a sensible trade-off on a 200k context window.

Sizes:
- `memory_char_limit`: 2200 → **40000** (~18x)
- `user_char_limit`: 1375 → **12000** (~8.7x)

The cap is a maximum, not a target. With 40k/12k headroom there's comfortable room for IPM prep, multi-session continuity, and the broader people/projects/conventions context without constant cap-friction.

After merge, Stakater Reloader picks up the config change and restarts Hermes automatically.