### PR TITLE
feat(paperless): upgrade to 3.0.0 with built-in AI via LiteLLM

### DIFF
--- a/kubernetes/apps/default/paperless/app/externalsecret.yaml
+++ b/kubernetes/apps/default/paperless/app/externalsecret.yaml
@@ -27,8 +27,11 @@ spec:
         INIT_POSTGRES_PASS: *dbPass
         INIT_POSTGRES_SUPER_USER: postgres
         INIT_POSTGRES_SUPER_PASS: "{{ .POSTGRES_SUPER_PASS }}"
+        PAPERLESS_AI_LLM_API_KEY: "{{ .LITELLM_MASTER_KEY }}"
   dataFrom:
     - extract:
         key: paperless
     - extract:
         key: cloudnative-pg
+    - extract:
+        key: litellm

--- a/kubernetes/apps/default/paperless/app/helmrelease.yaml
+++ b/kubernetes/apps/default/paperless/app/helmrelease.yaml
@@ -47,6 +47,13 @@ spec:
               PAPERLESS_ENABLE_COMPRESSION: false
               PAPERLESS_ENABLE_FLOWER: true
               PAPERLESS_OCR_SKIP_ARCHIVE_FILE: with_text
+              PAPERLESS_AI_ENABLED: true
+              PAPERLESS_AI_LLM_BACKEND: openai-like
+              PAPERLESS_AI_LLM_MODEL: deepseek-v4-flash
+              PAPERLESS_AI_LLM_ENDPOINT: https://litellm.goyangi.io/v1
+              PAPERLESS_AI_LLM_EMBEDDING_BACKEND: openai-like
+              PAPERLESS_AI_LLM_EMBEDDING_MODEL: qwen3-embedding
+              PAPERLESS_AI_LLM_OUTPUT_LANGUAGE: en
               USERMAP_UID: 1000
               USERMAP_GID: 1000
             envFrom:

--- a/kubernetes/apps/default/paperless/app/helmrelease.yaml
+++ b/kubernetes/apps/default/paperless/app/helmrelease.yaml
@@ -26,7 +26,7 @@ spec:
           app:
             image:
               repository: ghcr.io/paperless-ngx/paperless-ngx
-              tag: 2.20.15
+              tag: 3.0.0
             env:
               PAPERLESS_PORT: &port 8000
               PAPERLESS_TIME_ZONE: Australia/Sydney


### PR DESCRIPTION
Closes #4368

Builds on the Renovate image bump to 3.0.0 with:

- **Remove paperless-ai** - already removed from main
- **Configure built-in AI** from [PR #10319](https://github.com/paperless-ngx/paperless-ngx/pull/10319):
  - LLM backend: `openai-like` via LiteLLM at `https://litellm.goyangi.io/v1`
  - Model: `deepseek-v4-flash` for suggestions, titles, and document chat
  - Embeddings: `qwen3-embedding` via LiteLLM for local RAG
  - Output language: English
- **Secrets**: Added `LITELLM_MASTER_KEY` from 1Password as `PAPERLESS_AI_LLM_API_KEY`

The AI features (Suggest button, Document Chat) can be configured further from the Paperless UI.