### PR TITLE
feat(o11y): add kubectl-mcp and grafana-mcp servers to toolhive

### DIFF
--- a/kubernetes/apps/o11y/toolhive/mcp-servers/grafana-mcp/kustomization.yaml
+++ b/kubernetes/apps/o11y/toolhive/mcp-servers/grafana-mcp/kustomization.yaml
@@ -2,6 +2,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - ./grafana-mcp
-  - ./kubectl-mcp
-  - ./kubesearch
+  - ./mcpserverentry.yaml

--- a/kubernetes/apps/o11y/toolhive/mcp-servers/grafana-mcp/mcpserverentry.yaml
+++ b/kubernetes/apps/o11y/toolhive/mcp-servers/grafana-mcp/mcpserverentry.yaml
@@ -1,0 +1,13 @@
+---
+# Register the existing standalone grafana-mcp deployment with toolhive.
+# The actual deployment lives at kubernetes/apps/o11y/grafana-mcp/ (HelmRelease).
+apiVersion: toolhive.stacklok.dev/v1alpha1
+kind: MCPServerEntry
+metadata:
+  name: grafana
+  namespace: o11y
+spec:
+  remoteUrl: http://grafana-mcp.o11y.svc:8000/sse
+  transport: sse
+  groupRef:
+    name: mcp-tools

--- a/kubernetes/apps/o11y/toolhive/mcp-servers/kubectl-mcp/kustomization.yaml
+++ b/kubernetes/apps/o11y/toolhive/mcp-servers/kubectl-mcp/kustomization.yaml
@@ -2,6 +2,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - ./grafana-mcp
-  - ./kubectl-mcp
-  - ./kubesearch
+  - ./rbac.yaml
+  - ./mcpserver.yaml

--- a/kubernetes/apps/o11y/toolhive/mcp-servers/kubectl-mcp/mcpserver.yaml
+++ b/kubernetes/apps/o11y/toolhive/mcp-servers/kubectl-mcp/mcpserver.yaml
@@ -1,0 +1,39 @@
+---
+apiVersion: toolhive.stacklok.dev/v1alpha1
+kind: MCPServer
+metadata:
+  name: kubectl
+  namespace: o11y
+spec:
+  image: docker.io/rohitghumare64/kubectl-mcp-server:14f9c13@sha256:2cedffbd1b8439548d02342170c0570f2ecc1120ecf17a7a450ff2691f789b20
+  transport: streamable-http
+  proxyMode: streamable-http
+  proxyPort: 8080
+  mcpPort: 8000
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
+  serviceAccount: kubectl-mcp-readonly
+  podTemplateSpec:
+    spec:
+      containers:
+        - name: mcp
+          args:
+            - --transport
+            - streamable-http
+            - --host
+            - 0.0.0.0
+            - --port
+            - "8000"
+            - --read-only
+          env:
+            - name: MCP_K8S_PROVIDER
+              value: in-cluster
+            - name: PYTHONUNBUFFERED
+              value: "1"
+  groupRef:
+    name: mcp-tools

--- a/kubernetes/apps/o11y/toolhive/mcp-servers/kubectl-mcp/rbac.yaml
+++ b/kubernetes/apps/o11y/toolhive/mcp-servers/kubectl-mcp/rbac.yaml
@@ -1,0 +1,145 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kubectl-mcp-readonly
+  namespace: o11y
+---
+# Broad read-only access for kubectl MCP.
+# Core v1: everything except secrets, exec, and port-forward.
+# Non-core: all apiGroups — get/list/watch only, safe for read-only.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kubectl-mcp-readonly
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+rules:
+  - nonResourceURLs:
+      - /api
+      - /api/*
+      - /apis
+      - /apis/*
+      - /healthz
+      - /livez
+      - /openapi
+      - /openapi/*
+      - /readyz
+      - /version
+      - /version/
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - bindings
+      - componentstatuses
+      - configmaps
+      - endpoints
+      - events
+      - limitranges
+      - namespaces
+      - namespaces/status
+      - nodes
+      - nodes/status
+      - persistentvolumeclaims
+      - persistentvolumeclaims/status
+      - persistentvolumes
+      - persistentvolumes/status
+      - pods
+      - pods/log
+      - pods/status
+      - podtemplates
+      - replicationcontrollers
+      - replicationcontrollers/scale
+      - replicationcontrollers/status
+      - resourcequotas
+      - resourcequotas/status
+      - serviceaccounts
+      - services
+      - services/status
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - acme.cert-manager.io
+      - actions.github.com
+      - admissionregistration.k8s.io
+      - apiextensions.k8s.io
+      - apiregistration.k8s.io
+      - apps
+      - autoscaling
+      - autoscaling.home-ops.io
+      - batch
+      - cert-manager.io
+      - certificates.k8s.io
+      - cilium.io
+      - coordination.k8s.io
+      - discovery.k8s.io
+      - dragonflydb.io
+      - events.k8s.io
+      - extensions
+      - external-secrets.io
+      - externaldns.k8s.io
+      - flowcontrol.apiserver.k8s.io
+      - fluxcd.controlplane.io
+      - garage.rajsingh.info
+      - gateway.envoyproxy.io
+      - gateway.networking.k8s.io
+      - gateway.networking.x-k8s.io
+      - generators.external-secrets.io
+      - grafana.integreatly.org
+      - groupsnapshot.storage.k8s.io
+      - helm.toolkit.fluxcd.io
+      - image.toolkit.fluxcd.io
+      - infrastructure.giantswarm.io
+      - infra.contrib.fluxcd.io
+      - k8s.cni.cncf.io
+      - k8s.mariadb.com
+      - kopiur.home-operations.com
+      - kustomize.toolkit.fluxcd.io
+      - litellm.home-operations.com
+      - miroir.home-operations.com
+      - monitoring.coreos.com
+      - monitoring.giantswarm.io
+      - networking.k8s.io
+      - node.k8s.io
+      - notification.toolkit.fluxcd.io
+      - observability.giantswarm.io
+      - opentelemetry.io
+      - operator.victoriametrics.com
+      - pocketid.internal
+      - policy
+      - postgresql.cnpg.io
+      - rbac.authorization.k8s.io
+      - resource.k8s.io
+      - scheduling.k8s.io
+      - snapshot.storage.k8s.io
+      - source.toolkit.fluxcd.io
+      - storage.k8s.io
+      - tailscale.com
+      - talos.dev
+      - toolhive.stacklok.dev
+      - towonel.io
+      - tuppr.home-operations.com
+      - volsync.backube
+    resources:
+      - "*"
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kubectl-mcp-readonly
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kubectl-mcp-readonly
+subjects:
+  - kind: ServiceAccount
+    name: kubectl-mcp-readonly
+    namespace: o11y


### PR DESCRIPTION
Adds two new MCP servers to the toolhive VirtualMCPServer aggregation:

- **kubectl-mcp**: Read-only kubectl access via `rohitghumare64/kubectl-mcp-server` with dedicated ServiceAccount and ClusterRole (get/list/watch only, no secrets/exec/port-forward)
- **grafana-mcp**: MCPServerEntry registering the existing `grafana-mcp` HelmRelease deployment with toolhive for unified MCP aggregation

Both servers are added to the `mcp-tools` MCPGroup via `groupRef`.